### PR TITLE
fix broken call

### DIFF
--- a/pandora.py
+++ b/pandora.py
@@ -10,6 +10,7 @@ import glob
 import utils.utils as utils
 import utils.clinvar as clinvar
 import utils.database_actions as db
+import warnings
 from openpyxl import load_workbook
 from sqlalchemy import create_engine
 
@@ -95,7 +96,11 @@ def main():
 
     engine = create_engine(url)
 
+    # Ignore UserWarnings from setting dataframe attributes
+    warnings.simplefilter(action='ignore', category=UserWarning)
+
     # Identify cases in database which have a submission ID but no accession ID
+    print("Searching for variants will no accession ID...")
     cuh_submission_df = db.select_variants_from_db(288359, engine, "NOT NULL")
     nuh_submission_df = db.select_variants_from_db(509428, engine, "NOT NULL")
 
@@ -168,6 +173,9 @@ def main():
             else:
                 print(f"{file} has already been parsed. Skipping...")
 
+    else:
+        print("no path_to_workbooks to specified. Nothing to parse")
+
     # Select all variants that have interpreted = yes and are not submitted
     # Also exclude any variants meeting exclusion criteria set in the config
     if not args.hold_for_review:
@@ -197,7 +205,8 @@ def main():
                         engine.connect(),
                         df['local_id'].values
                     )
-
+    else:
+        print("hold_for_review specified. Variants will not be submitted.")
 
 if __name__ == "__main__":
     main()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -67,7 +67,7 @@ def get_workbook_data(workbook, config, filename, file, engine):
     if not all(errors):
         errors_to_add = [err for err in errors if err is not None]
         error_to_add = ", ".join(errors_to_add)
-        add_error_to_db(error_to_add, file, engine)
+        add_error_to_db(engine, file, error_to_add)
         return None
 
     return df_final


### PR DESCRIPTION
add_error_to_db() call had arguments in the wrong order

Also suppress recurring warning:
```
pandora.py:109: UserWarning: Pandas doesn't allow columns to be created via a new attribute name - see https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access
  nuh_submission_df.header = nuh_header
```
This warning is to stop columns being set using df.column = column, but that is not happening here, we are just tagging the df with its associated header and/or ACGS guidelines url

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/6)
<!-- Reviewable:end -->
