### PR TITLE
Adding new input, upgrade to SQLalchemy 2.0, fixing bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
 /tests
 *.png
 *.md
+uv.lock
+*.json
+*.log
+*.tmp
+*.tar.gz
+/data
+/appdata
+*.csv
+*.toml

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 *.log
 *.db
 *.sqlite3
-*.json
 log.txt
-.tar.gz
+*.tar.gz
 .coverage
 *.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+*.csv
+/data/
+*.log
+*.db
+*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.sqlite3
 *.json
 log.txt
+.tar.gz
+.coverage
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.log
 *.db
 *.sqlite3
+*.json
+log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 COPY requirements.txt requirements.txt
 
-# - Install requirements
-# - Delete unnecessary Python files
-# - Alias command `s3_upload` to `python3 s3_upload.py` for convenience
 RUN \
     pip install --quiet --upgrade pip && \
-    pip install -r requirements.txt && \
+    pip install uv && \
+    uv pip install --system --only-binary=all -r requirements.txt && \
 
     echo "Delete python cache directories" 1>&2 && \
-    find /usr/local/lib/python3.8 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | \
+    find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | \
     xargs rm -rf {} && \
 
     echo "Setting pandora alias" 1>&2 && \
-    printf '#!/bin/sh\npython3 /app/pandora.py "$@"'  > /usr/local/bin/pandora && \
+    printf '#!/bin/sh\nexec python3 /app/pandora.py "$@"\n' > /usr/local/bin/pandora && \
     chmod +x /usr/local/bin/pandora
 
 COPY . /app
 
-WORKDIR /app/pandora
+WORKDIR /app
 
-# display help if no args specified
 CMD pandora --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN \
     uv pip install --system --only-binary=all -r requirements.txt && \
 
     echo "Delete python cache directories" 1>&2 && \
-    find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | \
-    xargs rm -rf {} && \
+    find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) -print0 | \
+    xargs -0 -r rm -rf && \
 
     echo "Setting pandora alias" 1>&2 && \
     printf '#!/bin/sh\nexec python3 /app/pandora.py "$@"\n' > /usr/local/bin/pandora && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN \
     pip install --quiet --upgrade pip && \
     pip install uv && \
     uv pip install --system --only-binary=all -r requirements.txt && \
-
+    # Clean up unnecessary files
     echo "Delete python cache directories" 1>&2 && \
     find /usr/local/lib/python3.12 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) -print0 | \
     xargs -0 -r rm -rf && \
-
+    # Create pandora alias
     echo "Setting pandora alias" 1>&2 && \
     printf '#!/bin/sh\nexec python3 /app/pandora.py "$@"\n' > /usr/local/bin/pandora && \
     chmod +x /usr/local/bin/pandora

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This script searches a given folder for Excel variant workbooks that have not pr
 * `--print_submission_json`: (boolean) Default is False, if specified as True will print each clinvar submission to the terminal. This is useful for testing.
 * `--hold_for_review`: (boolean) Default is False, if specified as True, will add the variants to the database but not submit to ClinVar. Can be used to allow manual review before submission.
 * `--path_to_workbooks`: Local path to Excel workbooks that need submitting. If not specified, parsing will be skipped and the script will only run the accession ID retrieval process.
-* `--samples_file`: Local path to a CSV file containing sample information. If specified, the script will use this file instead of searching for workbooks. The CSV should have columns for `sample_id`, `workbook_path`.
-
+* `--samples_file`: Local path to a CSV file containing sample information. If specified, the script will use this file instead of searching for workbooks. The CSV should have columns for `file_name`, `sample_id`, `workbook_path`.
+* `--dry-run`: (boolean) Default is False, if specified as True, will not make any changes to the database or submit to ClinVar. Useful for testing.
 ## Example usage
 ```bash
 python clinvar_submissions.py \

--- a/README.md
+++ b/README.md
@@ -32,3 +32,27 @@ This script searches a given folder for Excel variant workbooks that have not pr
 * `--print_submission_json`: (boolean) Default is False, if specified as True will print each clinvar submission to the terminal. This is useful for testing.
 * `--hold_for_review`: (boolean) Default is False, if specified as True, will add the variants to the database but not submit to ClinVar. Can be used to allow manual review before submission.
 * `--path_to_workbooks`: Local path to Excel workbooks that need submitting. If not specified, parsing will be skipped and the script will only run the accession ID retrieval process.
+* `--samples_file`: Local path to a CSV file containing sample information. If specified, the script will use this file instead of searching for workbooks. The CSV should have columns for `sample_id`, `workbook_path`.
+
+## Example usage
+```bash
+python clinvar_submissions.py \
+    --clinvar_api_key clinvar_api_keys.json \
+    --db_credentials db_credentials.json \
+    --config config.json \
+    --clinvar_testing True \
+    --print_submission_json True \
+    --hold_for_review True \
+    --path_to_workbooks /path/to/workbooks/
+or
+python pandora.py \
+    --dry-run \
+    --clinvar_api_key clinvar_api_keys_test.json \
+    --db_credentials test_db_config.json \
+    --config test_db_config.json \
+    --clinvar_testing \
+    --print_submission_json \
+    --organisation "CUH" \
+    --hold_for_review \
+    --samples_file data/test_extract_file_250710.csv
+```

--- a/pandora.py
+++ b/pandora.py
@@ -65,14 +65,8 @@ def parse_args():
         '--config', required=True,
         help='JSON config file containing required inputs'
         )
-    parser.add_argument(
-        '--cuh', required=True,
-        help='boolean flag to determine whether handling CUH workbooks'
-        )
-    parser.add_argument(
-        '--nuh', required=True,
-        help='boolean flag to determine whether handling NUH workbooks'
-        )
+    parser.add_argument("--organisation", choices=["CUH", "NUH"], required=True,
+                        help="Organisation: CUH or NUH")
     args = parser.parse_args()
     return args
 
@@ -171,7 +165,12 @@ def main():
 
                 # Get a df of data from each sheet in workbook:
                 df = utils.get_workbook_data(
-                    workbook, config, filename, file, engine.connect()
+                    workbook,
+                    config,
+                    filename,
+                    file,
+                    engine.connect(),
+                    args.organisation
                 )
                 if df is not None:
                     if not df.empty:

--- a/pandora.py
+++ b/pandora.py
@@ -65,6 +65,14 @@ def parse_args():
         '--config', required=True,
         help='JSON config file containing required inputs'
         )
+    parser.add_argument(
+        '--cuh', required=True,
+        help='boolean flag to determine whether handling CUH workbooks'
+        )
+    parser.add_argument(
+        '--nuh', required=True,
+        help='boolean flag to determine whether handling NUH workbooks'
+        )
     args = parser.parse_args()
     return args
 

--- a/pandora.py
+++ b/pandora.py
@@ -120,42 +120,45 @@ def main():
     # Ignore UserWarnings from setting dataframe attributes
     warnings.simplefilter(action='ignore', category=UserWarning)
 
-    # Identify cases in database which have a submission ID but no accession ID
-    print("Searching for variants with no accession ID...")
-    cuh_submission_df = db.select_variants_from_db("288359", engine, "NOT NULL")
-    nuh_submission_df = db.select_variants_from_db("509428", engine, "NOT NULL")
-
-    print(
-        f"Found {nuh_submission_df.shape[0]} with submission IDs but no "
-        f"accession IDs for NUH.\nFound {cuh_submission_df.shape[0]} "
-        "with submission IDs but no accession IDs for CUH."
-        )
-
-    cuh_submission_df.header = cuh_header
-    nuh_submission_df.header = nuh_header
-
-    # If any exist, query clinvar API to retrieve accession IDs
-    for df in [cuh_submission_df, nuh_submission_df]:
-        if not df.empty:
-            for submission_id in list(df["submission_id"].unique()):
-                status, response = utils.submission_status_check(
-                    submission_id, df.header, api_url
-                )
-                accession_ids, errors = clinvar.process_submission_status(
-                    status, response
-                )
-
-                if accession_ids != {}:
-                    db.add_accession_ids_to_db(accession_ids, engine)
-
-                if errors != {}:
-                    db.add_clinvar_submission_error_to_db(
-                        errors, engine
-                    )
 
     if args.dry_run:
-        print("Dry run specified. No changes will be made to the database or "
-              "ClinVar.")
+        print("Dry run specified. No need to query DB and clinvar API. "
+              "No changes will be submitted to the database or ClinVar.")
+    else:
+        # Identify cases in database which have a submission ID but no accession ID
+        print("Searching for variants with no accession ID...")
+        cuh_submission_df = db.select_variants_from_db("288359", engine, "NOT NULL")
+        nuh_submission_df = db.select_variants_from_db("509428", engine, "NOT NULL")
+
+        print(
+            f"Found {nuh_submission_df.shape[0]} with submission IDs but no "
+            f"accession IDs for NUH.\nFound {cuh_submission_df.shape[0]} "
+            "with submission IDs but no accession IDs for CUH."
+            )
+
+        cuh_submission_df.header = cuh_header
+        nuh_submission_df.header = nuh_header
+
+        # If any exist, query clinvar API to retrieve accession IDs
+        for df in [cuh_submission_df, nuh_submission_df]:
+            if not df.empty:
+                for submission_id in list(df["submission_id"].unique()):
+                    status, response = utils.submission_status_check(
+                        submission_id, df.header, api_url
+                    )
+                    accession_ids, errors = clinvar.process_submission_status(
+                        status, response
+                    )
+
+                    if accession_ids != {}:
+                        db.add_accession_ids_to_db(accession_ids, engine)
+
+                    if errors != {}:
+                        db.add_clinvar_submission_error_to_db(
+                            errors, engine
+                        )
+
+
     # Get any new workbooks and re-run any failed workbooks in given path
     if args.path_to_workbooks:
         print(f"Searching {args.path_to_workbooks}...")

--- a/pandora.py
+++ b/pandora.py
@@ -12,6 +12,7 @@ import utils.clinvar as clinvar
 import utils.database_actions as db
 import warnings
 from openpyxl import load_workbook
+import pandas as pd
 from sqlalchemy import create_engine
 
 
@@ -58,15 +59,24 @@ def parse_args():
         '--db_credentials', required=True,
         help='JSON containing credentials to connect to AWS database'
         )
-    parser.add_argument(
-        '--path_to_workbooks', help='Path to variant workbooks'
-        )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        '--path_to_workbooks',
+        help='Path to variant workbooks'
+    )
+    group.add_argument(
+        '--samples_file',
+        help='Path to file containing Excel paths'
+    )
     parser.add_argument(
         '--config', required=True,
         help='JSON config file containing required inputs'
         )
-    parser.add_argument("--organisation", choices=["CUH", "NUH"], required=True,
-                        help="Organisation: CUH or NUH")
+    parser.add_argument('--organisation', choices=['CUH', 'NUH'], required=True,
+                        help='Organisation: CUH or NUH')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Run the script without making any changes '
+                        'to the database or submitting to ClinVar')
     args = parser.parse_args()
     return args
 
@@ -134,10 +144,18 @@ def main():
                         errors, engine.connect()
                     )
 
+    if args.dry_run:
+        print("Dry run specified. No changes will be made to the database or "
+              "ClinVar.")
     # Get any new workbooks and re-run any failed workbooks in given path
     if args.path_to_workbooks:
         print(f"Searching {args.path_to_workbooks}...")
         filenames = glob.glob(args.path_to_workbooks + "*.xlsx")
+        # remove any CNV workbooks
+        filenames = [f for f in filenames if not re.search(r'CNV', f, re.IGNORECASE)]
+        if not filenames:
+            print("No workbooks found in the specified path.")
+            SystemExit(1)
         print(f"Found {len(filenames)} workbooks")
 
         # Get previously parsed workbooks
@@ -172,16 +190,39 @@ def main():
                     engine.connect(),
                     args.organisation
                 )
-                if df is not None:
+                if args.dry_run:
+                    print("Parsed data:"
+                          f"\n{df.head()}\n{df.shape[0]} rows in total.")
+                    df = None
+                elif df is not None:
                     if not df.empty:
                         print(f"{df.shape[0]} variants to add to inca table.")
                         db.add_variants_to_db(df, engine.connect())
                     db.update_db_for_parsed_wb(file, engine.connect())
             else:
                 print(f"{file} has already been parsed. Skipping...")
+    elif args.samples_file:
+        print(f"Reading samples from {args.samples_file}...")
+        df = pd.read_csv("sample_file.csv")
+        paths = df[~df['file_name'].str.contains('CNV', case=False, na=False)]['path'].tolist()
+        print(f"Found {len(paths)} workbooks")
 
+        # Get previously parsed workbooks
+        parsed_workbook_df = db.select_workbooks_from_db(
+            engine, "parse_status = TRUE"
+        )
+        parsed_list = parsed_workbook_df['workbook_name'].values
+        failed_parsing_df = db.select_workbooks_from_db(
+            engine, "parse_status = FALSE"
+        )
+        failed_list = failed_parsing_df['workbook_name'].values
+
+        # Loop through each workbook in the samples file
+        for filename in paths:
+            print(f"Processing {filename}")
     else:
         print("no path_to_workbooks to specified. Nothing to parse")
+        SystemExit(1)
 
     # Select all variants that have interpreted = yes and are not submitted
     # Also exclude any variants meeting exclusion criteria set in the config

--- a/pandora.py
+++ b/pandora.py
@@ -13,6 +13,7 @@ import utils.database_actions as db
 import warnings
 from openpyxl import load_workbook
 import pandas as pd
+import re
 from sqlalchemy import create_engine
 
 
@@ -72,11 +73,19 @@ def parse_args():
         '--config', required=True,
         help='JSON config file containing required inputs'
         )
-    parser.add_argument('--organisation', choices=['CUH', 'NUH'], required=True,
-                        help='Organisation: CUH or NUH')
-    parser.add_argument('--dry-run', action='store_true',
-                        help='Run the script without making any changes '
-                        'to the database or submitting to ClinVar')
+    parser.add_argument(
+        '--organisation', choices=['CUH', 'NUH'], required=True,
+        help='Organisation: CUH or NUH'
+        )
+    parser.add_argument(
+        '--dry-run', action='store_true',
+        help='Run the script without making any changes '
+        'to the database or submitting to ClinVar'
+        )
+    parser.add_argument(
+        '--no-retry', action='store_true',
+        help='Do not retry failed submissions'
+    )
     args = parser.parse_args()
     return args
 
@@ -192,12 +201,13 @@ def main():
                 )
                 if args.dry_run:
                     print("Parsed data:"
-                          f"\n{df.head()}\n{df.shape[0]} rows in total.")
+                          f"\n{df.head()}\n{df.shape[0]} rows in total."
+                    )
                     df = None
                 elif df is not None:
                     if not df.empty:
                         print(f"{df.shape[0]} variants to add to inca table.")
-                        db.add_variants_to_db(df, engine.connect())
+                        db.add_variants_to_db(df, engine)
                     db.update_db_for_parsed_wb(file, engine)
             else:
                 print(f"{file} has already been parsed. Skipping...")
@@ -241,12 +251,15 @@ def main():
                 )
                 if args.dry_run:
                     print("Parsed data:"
-                          f"\n{df.head()}\n{df.shape[0]} rows in total.") # type: ignore
+                          f"\n{df.head()}\n{df.shape[0]} rows in total."
+                    )
+                    df.to_csv("parsed_data.csv", index=False)
+                    print("Saved parsed data to parsed_data.csv")
                     df = None
                 elif df is not None:
                     if not df.empty:
                         print(f"{df.shape[0]} variants to add to inca table.")
-                        db.add_variants_to_db(df, engine.connect())
+                        db.add_variants_to_db(df, engine)
                     db.update_db_for_parsed_wb(file, engine)
             else:
                 print(f"{file} has already been parsed. Skipping...")
@@ -275,12 +288,13 @@ def main():
                 )
                 response = clinvar.clinvar_api_request(
                     api_url, df.header, variants, df.url,
-                    args.print_submission_json
+                    args.print_submission_json,
+                    args.no_retry
                 )
                 if args.clinvar_testing is False:
                     db.add_submission_id_to_db(
                         response.json(),
-                        engine.connect(),
+                        engine,
                         df['local_id'].values
                     )
     else:

--- a/pandora.py
+++ b/pandora.py
@@ -191,7 +191,8 @@ def main():
                 )
                 workbook = load_workbook(filename)
                 if file not in failed_list:
-                    db.add_wb_to_db(file, None, engine) # Was NULL
+                    db.add_wb_to_db(file, None, engine)
+                    # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
 
                 # Get a df of data from each sheet in workbook:
                 df = utils.get_workbook_data(

--- a/pandora.py
+++ b/pandora.py
@@ -163,12 +163,14 @@ def main():
     # Get config values
     if args.path_to_workbooks:
         print(f"Searching {args.path_to_workbooks}...")
-        filenames = glob.glob(args.path_to_workbooks + "*.xlsx")
+        filenames = glob.glob(
+            os.path.join(args.path_to_workbooks, "*.xlsx")
+        )
         # remove any CNV workbooks
         workbooks_to_process = [f for f in filenames if not re.search(r'CNV', f, re.IGNORECASE)]
         if not filenames:
             print("No workbooks found in the specified path.")
-            SystemExit(1)
+            raise SystemExit(1)
         print(f"Found {len(workbooks_to_process)} workbooks")
 
     elif args.samples_file:
@@ -199,8 +201,8 @@ def main():
             )
             workbook = load_workbook(filename)
             if file not in failed_list:
-                db.add_wb_to_db(file, None, engine)
                 # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
+                db.add_wb_to_db(file, None, engine)
             # Get a df of data from each sheet in workbook:
             df = utils.get_workbook_data(
                 workbook,
@@ -229,7 +231,7 @@ def main():
 
     else:
         print("no path_to_workbooks to specified. Nothing to parse")
-        SystemExit(1)
+        raise SystemExit(1)
 
     # Select all variants that have interpreted = yes and are not submitted
     # Also exclude any variants meeting exclusion criteria set in the config

--- a/pandora.py
+++ b/pandora.py
@@ -108,7 +108,7 @@ def main():
     warnings.simplefilter(action='ignore', category=UserWarning)
 
     # Identify cases in database which have a submission ID but no accession ID
-    print("Searching for variants will no accession ID...")
+    print("Searching for variants with no accession ID...")
     cuh_submission_df = db.select_variants_from_db(288359, engine, "NOT NULL")
     nuh_submission_df = db.select_variants_from_db(509428, engine, "NOT NULL")
 

--- a/pandora.py
+++ b/pandora.py
@@ -172,7 +172,6 @@ def main():
             print("No workbooks found in the specified path.")
             raise SystemExit(1)
         print(f"Found {len(workbooks_to_process)} workbooks")
-
     elif args.samples_file:
         print(f"Reading samples from {args.samples_file}...")
         df = pd.read_csv(f"{args.samples_file}")
@@ -229,9 +228,6 @@ def main():
         else:
             print(f"{file} has already been parsed. Skipping...")
 
-    else:
-        print("no path_to_workbooks to specified. Nothing to parse")
-        raise SystemExit(1)
 
     # Select all variants that have interpreted = yes and are not submitted
     # Also exclude any variants meeting exclusion criteria set in the config

--- a/pandora.py
+++ b/pandora.py
@@ -17,9 +17,9 @@ from sqlalchemy import create_engine
 
 def open_json(file):
     '''
-    Inputs
+    Inputs:
         file (str): path to json file
-    Outputs
+    Outputs:
         contents (dict): the contents of that JSON as a dict
     '''
     with open(file) as f:

--- a/pandora.py
+++ b/pandora.py
@@ -113,8 +113,8 @@ def main():
 
     # Identify cases in database which have a submission ID but no accession ID
     print("Searching for variants with no accession ID...")
-    cuh_submission_df = db.select_variants_from_db(288359, engine, "NOT NULL")
-    nuh_submission_df = db.select_variants_from_db(509428, engine, "NOT NULL")
+    cuh_submission_df = db.select_variants_from_db("288359", engine, "NOT NULL")
+    nuh_submission_df = db.select_variants_from_db("509428", engine, "NOT NULL")
 
     print(
         f"Found {nuh_submission_df.shape[0]} with submission IDs but no "
@@ -141,7 +141,7 @@ def main():
 
                 if errors != {}:
                     db.add_clinvar_submission_error_to_db(
-                        errors, engine.connect()
+                        errors, engine
                     )
 
     if args.dry_run:
@@ -179,7 +179,7 @@ def main():
                 )
                 workbook = load_workbook(filename)
                 if file not in failed_list:
-                    db.add_wb_to_db(file, "NULL", engine.connect())
+                    db.add_wb_to_db(file, None, engine) # Was NULL
 
                 # Get a df of data from each sheet in workbook:
                 df = utils.get_workbook_data(
@@ -187,7 +187,7 @@ def main():
                     config,
                     filename,
                     file,
-                    engine.connect(),
+                    engine,
                     args.organisation
                 )
                 if args.dry_run:
@@ -198,12 +198,12 @@ def main():
                     if not df.empty:
                         print(f"{df.shape[0]} variants to add to inca table.")
                         db.add_variants_to_db(df, engine.connect())
-                    db.update_db_for_parsed_wb(file, engine.connect())
+                    db.update_db_for_parsed_wb(file, engine)
             else:
                 print(f"{file} has already been parsed. Skipping...")
     elif args.samples_file:
         print(f"Reading samples from {args.samples_file}...")
-        df = pd.read_csv("sample_file.csv")
+        df = pd.read_csv(f"{args.samples_file}")
         paths = df[~df['file_name'].str.contains('CNV', case=False, na=False)]['path'].tolist()
         print(f"Found {len(paths)} workbooks")
 
@@ -220,6 +220,36 @@ def main():
         # Loop through each workbook in the samples file
         for filename in paths:
             print(f"Processing {filename}")
+            file = os.path.basename(filename)
+            if file not in parsed_list:
+                print(
+                    f"{file} has not previously been parsed successfully.\n"
+                    f"Parsing {file}..."
+                )
+                workbook = load_workbook(filename)
+                if file not in failed_list:
+                    db.add_wb_to_db(file, None, engine) # Was NULL
+
+                # Get a df of data from each sheet in workbook:
+                df = utils.get_workbook_data(
+                    workbook,
+                    config,
+                    filename,
+                    file,
+                    engine,
+                    args.organisation
+                )
+                if args.dry_run:
+                    print("Parsed data:"
+                          f"\n{df.head()}\n{df.shape[0]} rows in total.") # type: ignore
+                    df = None
+                elif df is not None:
+                    if not df.empty:
+                        print(f"{df.shape[0]} variants to add to inca table.")
+                        db.add_variants_to_db(df, engine.connect())
+                    db.update_db_for_parsed_wb(file, engine)
+            else:
+                print(f"{file} has already been parsed. Skipping...")
     else:
         print("no path_to_workbooks to specified. Nothing to parse")
         SystemExit(1)
@@ -228,8 +258,8 @@ def main():
     # Also exclude any variants meeting exclusion criteria set in the config
     if not args.hold_for_review:
         exclude = config["exclude"]
-        cuh_df = db.select_variants_from_db(288359, engine, "NULL", exclude)
-        nuh_df = db.select_variants_from_db(509428, engine, "NULL", exclude)
+        cuh_df = db.select_variants_from_db("288359", engine, "NULL", exclude)
+        nuh_df = db.select_variants_from_db("509428", engine, "NULL", exclude)
         print(
             f"Found {nuh_df.shape[0]} interpreted variants to submit for NUH.\n"
             f"Found {cuh_df.shape[0]} interpreted variants to submit for CUH."

--- a/pandora.py
+++ b/pandora.py
@@ -17,7 +17,7 @@ import re
 from sqlalchemy import create_engine
 
 
-def open_json(file):
+def open_json(file: str) -> dict:
     '''
     Inputs:
         file (str): path to json file
@@ -29,7 +29,7 @@ def open_json(file):
     return contents
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     '''
     Parse command line arguments
     '''
@@ -158,115 +158,75 @@ def main():
                             errors, engine
                         )
 
-
-    # Get any new workbooks and re-run any failed workbooks in given path
+    # Gather workbooks to process
+    workbooks_to_process = []
+    # Get config values
     if args.path_to_workbooks:
         print(f"Searching {args.path_to_workbooks}...")
         filenames = glob.glob(args.path_to_workbooks + "*.xlsx")
         # remove any CNV workbooks
-        filenames = [f for f in filenames if not re.search(r'CNV', f, re.IGNORECASE)]
+        workbooks_to_process = [f for f in filenames if not re.search(r'CNV', f, re.IGNORECASE)]
         if not filenames:
             print("No workbooks found in the specified path.")
             SystemExit(1)
-        print(f"Found {len(filenames)} workbooks")
+        print(f"Found {len(workbooks_to_process)} workbooks")
 
-        # Get previously parsed workbooks
-        parsed_workbook_df = db.select_workbooks_from_db(
-            engine, "parse_status = TRUE"
-        )
-        parsed_list = parsed_workbook_df['workbook_name'].values
-        failed_parsing_df = db.select_workbooks_from_db(
-            engine, "parse_status = FALSE"
-        )
-        failed_list = failed_parsing_df['workbook_name'].values
-
-        for filename in filenames:
-            print(f"Processing {filename}")
-            # check if wb has not already been processed
-            file = os.path.basename(filename)
-            if file not in parsed_list:
-                print(
-                    f"{file} has not previously been parsed successfully.\n"
-                    f"Parsing {file}..."
-                )
-                workbook = load_workbook(filename)
-                if file not in failed_list:
-                    db.add_wb_to_db(file, None, engine)
-                    # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
-
-                # Get a df of data from each sheet in workbook:
-                df = utils.get_workbook_data(
-                    workbook,
-                    config,
-                    filename,
-                    file,
-                    engine,
-                    args.organisation
-                )
-                if args.dry_run:
-                    print("Parsed data:"
-                          f"\n{df.head()}\n{df.shape[0]} rows in total."
-                    )
-                    df = None
-                elif df is not None:
-                    if not df.empty:
-                        print(f"{df.shape[0]} variants to add to inca table.")
-                        db.add_variants_to_db(df, engine)
-                    db.update_db_for_parsed_wb(file, engine)
-            else:
-                print(f"{file} has already been parsed. Skipping...")
     elif args.samples_file:
         print(f"Reading samples from {args.samples_file}...")
         df = pd.read_csv(f"{args.samples_file}")
-        paths = df[~df['file_name'].str.contains('CNV', case=False, na=False)]['path'].tolist()
-        print(f"Found {len(paths)} workbooks")
+        workbooks_to_process = df[~df['file_name'].str.contains('CNV', case=False, na=False)]['path'].tolist()
+        print(f"Found {len(workbooks_to_process)} workbooks")
 
-        # Get previously parsed workbooks
-        parsed_workbook_df = db.select_workbooks_from_db(
-            engine, "parse_status = TRUE"
-        )
-        parsed_list = parsed_workbook_df['workbook_name'].values
-        failed_parsing_df = db.select_workbooks_from_db(
-            engine, "parse_status = FALSE"
-        )
-        failed_list = failed_parsing_df['workbook_name'].values
+    # Get previously parsed workbooks
+    parsed_workbook_df = db.select_workbooks_from_db(
+        engine, "parse_status = TRUE"
+    )
+    parsed_list = parsed_workbook_df['workbook_name'].values
+    failed_parsing_df = db.select_workbooks_from_db(
+        engine, "parse_status = FALSE"
+    )
+    failed_list = failed_parsing_df['workbook_name'].values
 
-        # Loop through each workbook in the samples file
-        for filename in paths:
-            print(f"Processing {filename}")
-            file = os.path.basename(filename)
-            if file not in parsed_list:
-                print(
-                    f"{file} has not previously been parsed successfully.\n"
-                    f"Parsing {file}..."
+    # Process workbooks
+    for filename in workbooks_to_process:
+        print(f"Processing {filename}")
+        # check if wb has not already been processed
+        file = os.path.basename(filename)
+        if file not in parsed_list:
+            print(
+                f"{file} has not previously been parsed successfully.\n"
+                f"Parsing {file}..."
+            )
+            workbook = load_workbook(filename)
+            if file not in failed_list:
+                db.add_wb_to_db(file, None, engine)
+                # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
+            # Get a df of data from each sheet in workbook:
+            df = utils.get_workbook_data(
+                workbook,
+                config,
+                filename,
+                file,
+                engine,
+                args.organisation
+            )
+            if df is None:
+                print("No data parsed from workbook.")
+                continue
+            # If we reach this point, we have valid data
+            if args.dry_run:
+                print("Parsed data:"
+                      f"\n{df.head()}\n{df.shape[0]} rows in total."
                 )
-                workbook = load_workbook(filename)
-                if file not in failed_list:
-                    db.add_wb_to_db(file, None, engine) # Was NULL
-
-                # Get a df of data from each sheet in workbook:
-                df = utils.get_workbook_data(
-                    workbook,
-                    config,
-                    filename,
-                    file,
-                    engine,
-                    args.organisation
-                )
-                if args.dry_run:
-                    print("Parsed data:"
-                          f"\n{df.head()}\n{df.shape[0]} rows in total."
-                    )
-                    df.to_csv("parsed_data.csv", index=False)
-                    print("Saved parsed data to parsed_data.csv")
-                    df = None
-                elif df is not None:
-                    if not df.empty:
-                        print(f"{df.shape[0]} variants to add to inca table.")
-                        db.add_variants_to_db(df, engine)
-                    db.update_db_for_parsed_wb(file, engine)
+                df = None
             else:
-                print(f"{file} has already been parsed. Skipping...")
+                if not df.empty:
+                    print(f"{df.shape[0]} variants to add to inca table.")
+                    db.add_variants_to_db(df, engine)
+                db.update_db_for_parsed_wb(file, engine)
+        else:
+            print(f"{file} has already been parsed. Skipping...")
+
     else:
         print("no path_to_workbooks to specified. Nothing to parse")
         SystemExit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.26.4
 freezegun==1.5.1
-pandas==2.0.3
+pandas==2.3.1
 openpyxl==3.1.2
 psycopg2-binary==2.9.10
 pytest==7.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.21.4
+numpy==1.26.4
 freezegun==1.5.1
 pandas==2.0.3
 openpyxl==3.1.2
 psycopg2-binary==2.9.10
 pytest==7.2.0
-requests==2.22.0
+requests==2.32.4
 sqlalchemy==1.4.52

--- a/tests/test_data/test_config.json
+++ b/tests/test_data/test_config.json
@@ -255,7 +255,7 @@
         "PVS": "Very Strong",
         "PS": "Strong",
         "PM": "Moderate",
-        "PP": "Supporting",    
+        "PP": "Supporting",
         "BS": "Supporting",
         "BA": "Stand-Alone",
         "BP": "Supporting"

--- a/tests/test_database_actions.py
+++ b/tests/test_database_actions.py
@@ -8,61 +8,50 @@ import pandas as pd
 
 
 class TestDatabaseEngine(unittest.TestCase):
-    '''
+    """
     Test all the functions in database_actions which generate SQL queries to
     read from the database using the SQLAlchemy engine directly
-    '''
-    variants = ['uid_12345', 'uid_67890']
+    """
 
-    # @freeze_time("2024-07-10 22:22:22")
-    # def test_add_wb_to_db(self):
-    #     '''
-    #     Test that add_wb_to_db is called with the expected SQL when given
-    #     example inputs
-    #     '''
-    #     mock_engine = mock.MagicMock()
-    #     expected_sql = (
-    #         "INSERT INTO testdirectory.inca_workbooks "
-    #         "(workbook_name, date, parse_status) "
-    #         "VALUES ('test_workbook.xlsx', '2024-07-10 22:22:22', FAIL) "
-    #         "ON CONFLICT (workbook_name) DO NOTHING"
-    #     )
-    #     db.add_wb_to_db('test_workbook.xlsx', 'FAIL', mock_engine)
-    #     mock_engine.execute.assert_called_once_with(expected_sql)
+    variants = ["uid_12345", "uid_67890"]
 
     @freeze_time("2024-07-10 22:22:22")
     def test_add_wb_to_db(self):
-        '''
+        """
         Test that add_wb_to_db is called with the expected SQL when given
         example inputs
-        '''
+        """
+        # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = mock_conn
 
         expected_call = call(
-            ANY,
-            {"wb": 'test_workbook.xlsx', "date": mock.ANY, "status": 'FAIL'}
+            ANY, {"wb": "test_workbook.xlsx", "date": mock.ANY, "status": "FAIL"}
         )
 
-        db.add_wb_to_db('test_workbook.xlsx', 'FAIL', mock_engine)
-        mock_engine.execute.assert_called_once_with(
-            mock.ANY,
-            {"wb": 'test_workbook.xlsx', "date": mock.ANY, "status": 'FAIL'}
+        db.add_wb_to_db("test_workbook.xlsx", "FAIL", mock_engine)
+        mock_conn.execute.assert_called_once_with(
+            mock.ANY, {"wb": "test_workbook.xlsx", "date": mock.ANY, "status": "FAIL"}
         )
         # Check expected call was made
-        self.assertIn(expected_call, mock_engine.execute.call_args_list)
+        self.assertIn(expected_call, mock_conn.execute.call_args_list)
 
     def test_update_db_for_parsed_wb(self):
+        # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = mock_conn
 
-        db.update_db_for_parsed_wb('test_workbook.xlsx', mock_engine)
+        db.update_db_for_parsed_wb("test_workbook.xlsx", mock_engine)
 
         # Check that execute was called once
-        mock_engine.execute.assert_called_once()
+        mock_conn.execute.assert_called_once()
 
         # Get the call arguments
-        call_args = mock_engine.execute.call_args
+        call_args = mock_conn.execute.call_args
         sql_text_obj = call_args[0][0]  # First argument (the text object)
-        params = call_args[0][1]        # Second argument (the parameters dict)
+        params = call_args[0][1]  # Second argument (the parameters dict)
 
         # Convert text object to string to check SQL content
         actual_sql = str(sql_text_obj)
@@ -73,14 +62,12 @@ class TestDatabaseEngine(unittest.TestCase):
             self.assertIn("WHERE workbook_name = :wb", actual_sql)
 
         with self.subTest("Parameters are correct"):
-            expected_params = {
-                'wb': 'test_workbook.xlsx'
-            }
+            expected_params = {"wb": "test_workbook.xlsx"}
             self.assertEqual(params, expected_params)
 
     def test_add_submission_id_to_db_if_submission_id_returned(self):
         mock_engine = mock.MagicMock()
-        response = {'id': 'SUB123456'}
+        response = {"id": "SUB123456"}
         expected_sql = (
             "UPDATE testdirectory.inca SET submission_id = 'SUB123456' "
             "WHERE local_id in ('uid_12345', 'uid_67890')"
@@ -90,7 +77,7 @@ class TestDatabaseEngine(unittest.TestCase):
 
     def test_add_submission_id_to_db_if_error_returned(self):
         mock_engine = mock.MagicMock()
-        response = {'message': "No valid API key provided"}
+        response = {"message": "No valid API key provided"}
         expected_sql = (
             "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: No valid "
             "API key provided' WHERE local_id in ('uid_12345', 'uid_67890')"
@@ -99,17 +86,20 @@ class TestDatabaseEngine(unittest.TestCase):
         mock_engine.execute.assert_called_once_with(expected_sql)
 
     def test_add_error_to_db(self):
+        # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = mock_conn
 
-        db.add_error_to_db(mock_engine, 'test_workbook.xlsx', 'Parsing error')
+        db.add_error_to_db(mock_engine, "test_workbook.xlsx", "Parsing error")
 
         # Check that execute was called once
-        mock_engine.execute.assert_called_once()
+        mock_conn.execute.assert_called_once()
 
         # Get the call arguments
-        call_args = mock_engine.execute.call_args
+        call_args = mock_conn.execute.call_args
         sql_text_obj = call_args[0][0]  # First argument (the text object)
-        params = call_args[0][1]        # Second argument (the parameters dict)
+        params = call_args[0][1]  # Second argument (the parameters dict)
 
         # Convert text object to string to check SQL content
         actual_sql = str(sql_text_obj)
@@ -121,18 +111,12 @@ class TestDatabaseEngine(unittest.TestCase):
             self.assertIn("WHERE workbook_name = :wb", actual_sql)
 
         with self.subTest("Parameters are correct"):
-            expected_params = {
-                'err': 'Parsing error',
-                'wb': 'test_workbook.xlsx'
-            }
+            expected_params = {"err": "Parsing error", "wb": "test_workbook.xlsx"}
             self.assertEqual(params, expected_params)
 
     def test_add_accession_ids_to_db(self):
         mock_engine = mock.MagicMock()
-        accession_ids = {
-            'uid_12345': 'SCV000012345',
-            'uid_67890': 'SCV000067890'
-        }
+        accession_ids = {"uid_12345": "SCV000012345", "uid_67890": "SCV000067890"}
 
         db.add_accession_ids_to_db(accession_ids, mock_engine)
 
@@ -143,78 +127,90 @@ class TestDatabaseEngine(unittest.TestCase):
         calls = mock_engine.execute.call_args_list
 
         # Extract the parameters from each call
-        call_params = [call[0][1] for call in calls]  # Get the second argument (params dict)
+        call_params = [
+            call[0][1] for call in calls
+        ]  # Get the second argument (params dict)
 
         expected_params = [
-            {'accession': 'SCV000012345', 'local_id': 'uid_12345'},
-            {'accession': 'SCV000067890', 'local_id': 'uid_67890'}
+            {"accession": "SCV000012345", "local_id": "uid_12345"},
+            {"accession": "SCV000067890", "local_id": "uid_67890"},
         ]
 
         # Check that both sets of parameters were used
         for expected in expected_params:
             self.assertIn(expected, call_params)
 
-
-    def test_add_clinvar_submission_error_to_db(self):
-
+    @mock.patch("utils.database_actions.text")
+    def test_add_clinvar_submission_error_to_db(self, mock_text):
+        # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+
         errors = {
-            'uid_12345': 'This record is submitted as novel but it should be '
-            'submitted as an update',
-            'uid_67890': 'The identifier you provided (MONDO:MONDO:0000) '
-            'cannot be validated'
+            "uid_12345": "This record is submitted as novel but it should be submitted as an update",
+            "uid_67890": "The identifier you provided (MONDO:MONDO:0000) cannot be validated",
         }
 
-        expected_calls = [
-            call(ANY, {'error': 'This record is submitted as novel but it should be submitted as an update', 'local_id': 'uid_12345'}),
-            call(ANY, {'error': 'The identifier you provided (MONDO:MONDO:0000) cannot be validated', 'local_id': 'uid_67890'}),
-        ]
-
+        # Call the function
         db.add_clinvar_submission_error_to_db(errors, mock_engine)
 
-        assert mock_engine.execute.call_count == 2
-        mock_engine.execute.assert_has_calls(expected_calls, any_order=True)
+        # Check that execute was called for each error
+        expected_calls = [
+            call(
+                mock_text.return_value,
+                {"error": errors["uid_12345"], "local_id": "uid_12345"},
+            ),
+            call(
+                mock_text.return_value,
+                {"error": errors["uid_67890"], "local_id": "uid_67890"},
+            ),
+        ]
+        assert mock_conn.execute.call_count == 2
+        mock_conn.execute.assert_has_calls(expected_calls, any_order=True)
 
 
 class TestDatabasePandas(unittest.TestCase):
-    '''
+    """
     Test all the functions in database_actions which interact with the
     database via pandas processes
-    '''
-    data = [{
-        "local_id": "uid-123456789",
-        "linking_id": "uid-123456789",
-        "chromosome": 7,
-        "start": 117232266,
-        "reference_allele": "C",
-        "alternate_allele": "CA",
-        "gene_symbol": "CFTR",
-        "comment_on_classification": "PVS1,PM3_Strong",
-        "germline_classification": "Pathogenic",
-        "date_last_evaluated": "2024-10-10",
-        "preferred_condition_name": "Cystic fibrosis",
-        "collection_method": "clinical testing",
-        "affected_status": "yes",
-        "allele_origin": "germline",
-        "ref_genome": "GRCh37.p13",
-    }]
+    """
+
+    data = [
+        {
+            "local_id": "uid-123456789",
+            "linking_id": "uid-123456789",
+            "chromosome": 7,
+            "start": 117232266,
+            "reference_allele": "C",
+            "alternate_allele": "CA",
+            "gene_symbol": "CFTR",
+            "comment_on_classification": "PVS1,PM3_Strong",
+            "germline_classification": "Pathogenic",
+            "date_last_evaluated": "2024-10-10",
+            "preferred_condition_name": "Cystic fibrosis",
+            "collection_method": "clinical testing",
+            "affected_status": "yes",
+            "allele_origin": "germline",
+            "ref_genome": "GRCh37.p13",
+        }
+    ]
     df = pd.DataFrame(data)
 
-    @mock.patch('pandas.DataFrame.to_sql')
+    @mock.patch("pandas.DataFrame.to_sql")
     def test_add_variants_to_db(self, pd_to_sql_mock):
         mock_engine = mock.MagicMock()
         db.add_variants_to_db(self.df, mock_engine)
         pd_to_sql_mock.assert_called_once_with(
-            "inca", mock_engine, if_exists='append', schema='testdirectory',
-            index=False
+            "inca", mock_engine, if_exists="append", schema="testdirectory", index=False
         )
 
-    @mock.patch('pandas.read_sql')
+    @mock.patch("pandas.read_sql")
     def test_select_variants_from_db(self, pd_read_sql_mock):
         mock_engine = mock.MagicMock()
         pd_read_sql_mock.return_value = self.df
 
-        return_df = db.select_variants_from_db(1234, mock_engine, 'NOT NULL')
+        return_df = db.select_variants_from_db("1234", mock_engine, "NOT NULL")
 
         with self.subTest("Returns value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, self.df)
@@ -225,9 +221,8 @@ class TestDatabasePandas(unittest.TestCase):
             call_args = pd_read_sql_mock.call_args
             # First arg should be a text object, second should be engine, third should be params
             self.assertEqual(len(call_args[0]), 2)  # Two positional args
-            self.assertIn('params', call_args[1])  # params as keyword arg
-            self.assertEqual(call_args[1]['params'], {'org_id': 1234})
-
+            self.assertIn("params", call_args[1])  # params as keyword arg
+            self.assertEqual(call_args[1]["params"], {"org_id": "1234"})
 
     def assertSQLContains(self, mock_call, expected_fragments, expected_params=None):
         """Helper method to assert SQL content and parameters"""
@@ -245,16 +240,16 @@ class TestDatabasePandas(unittest.TestCase):
 
         # Check parameters if provided
         if expected_params:
-            params = call_args[1].get('params', {})
+            params = call_args[1].get("params", {})
             for key, value in expected_params.items():
                 self.assertEqual(params[key], value)
 
-    @mock.patch('pandas.read_sql')
+    @mock.patch("pandas.read_sql")
     def test_select_variants_from_db_with_sql_check(self, pd_read_sql_mock):
         mock_engine = mock.MagicMock()
         pd_read_sql_mock.return_value = self.df
 
-        return_df = db.select_variants_from_db(1234, mock_engine, 'NOT NULL')
+        return_df = db.select_variants_from_db("1234", mock_engine, "NOT NULL")
 
         # Use helper to check SQL
         expected_fragments = [
@@ -262,25 +257,23 @@ class TestDatabasePandas(unittest.TestCase):
             "WHERE interpreted = 'yes'",
             "submission_id IS NOT NULL",
             "organisation_id = :org_id",
-            "allele_origin = 'germline'"
+            "allele_origin = 'germline'",
         ]
-        expected_params = {'org_id': 1234}
+        expected_params = {"org_id": "1234"}
 
         self.assertSQLContains(pd_read_sql_mock, expected_fragments, expected_params)
 
-    @mock.patch('pandas.read_sql')
+    @mock.patch("pandas.read_sql")
     def test_select_variants_from_db_with_exclude(self, pd_read_sql_mock):
-        '''
+        """
         Test that when an exclude value is passed to select_variants_from_db
         it is added to the query
-        '''
+        """
         mock_engine = mock.MagicMock()
         exclude = " AND panel != '_HGNC:7527'"
         pd_read_sql_mock.return_value = self.df
 
-        return_df = db.select_variants_from_db(
-            1234, mock_engine, 'NULL', exclude
-        )
+        return_df = db.select_variants_from_db("1234", mock_engine, "NULL", exclude)
 
         with self.subTest("Returns mocked value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, self.df)
@@ -298,22 +291,16 @@ class TestDatabasePandas(unittest.TestCase):
             self.assertIn("allele_origin = 'germline'", sql_text)
             self.assertIn("panel != '_HGNC:7527'", sql_text)  # The exclude part
 
-            self.assertEqual(call_args[1]['params'], {'org_id': 1234})
+            self.assertEqual(call_args[1]["params"], {"org_id": "1234"})
 
-
-    @mock.patch('pandas.read_sql')
+    @mock.patch("pandas.read_sql")
     def test_select_wb_from_db(self, pd_read_sql_mock):
         mock_engine = mock.MagicMock()
-        data = {
-            "workbook_name": ['test_wb.xlsx'],
-            "parse_status": False
-        }
+        data = {"workbook_name": ["test_wb.xlsx"], "parse_status": False}
         df = pd.DataFrame(data)
         pd_read_sql_mock.return_value = df
 
-        return_df = db.select_workbooks_from_db(
-            mock_engine, "parse_status = FALSE"
-        )
+        return_df = db.select_workbooks_from_db(mock_engine, "parse_status = FALSE")
 
         with self.subTest("Returns mocked value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, df)

--- a/tests/test_database_actions.py
+++ b/tests/test_database_actions.py
@@ -5,6 +5,7 @@ from unittest.mock import call
 from freezegun import freeze_time
 import utils.database_actions as db
 import pandas as pd
+from itertools import chain
 
 
 class TestDatabaseEngine(unittest.TestCase):
@@ -24,7 +25,7 @@ class TestDatabaseEngine(unittest.TestCase):
         # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
         mock_conn = mock.MagicMock()
-        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
 
         expected_call = call(
             ANY, {"wb": "test_workbook.xlsx", "date": mock.ANY, "status": "FAIL"}
@@ -41,7 +42,7 @@ class TestDatabaseEngine(unittest.TestCase):
         # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
         mock_conn = mock.MagicMock()
-        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
 
         db.update_db_for_parsed_wb("test_workbook.xlsx", mock_engine)
 
@@ -67,29 +68,35 @@ class TestDatabaseEngine(unittest.TestCase):
 
     def test_add_submission_id_to_db_if_submission_id_returned(self):
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        # Patch engine.begin().__enter__() to return mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
         response = {"id": "SUB123456"}
         expected_sql = (
             "UPDATE testdirectory.inca SET submission_id = 'SUB123456' "
             "WHERE local_id in ('uid_12345', 'uid_67890')"
         )
         db.add_submission_id_to_db(response, mock_engine, self.variants)
-        mock_engine.execute.assert_called_once_with(expected_sql)
+        mock_conn.execute.assert_called_once_with(expected_sql)
 
     def test_add_submission_id_to_db_if_error_returned(self):
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        # Patch engine.begin().__enter__() to return mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
         response = {"message": "No valid API key provided"}
         expected_sql = (
             "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: No valid "
             "API key provided' WHERE local_id in ('uid_12345', 'uid_67890')"
         )
         db.add_submission_id_to_db(response, mock_engine, self.variants)
-        mock_engine.execute.assert_called_once_with(expected_sql)
+        mock_conn.execute.assert_called_once_with(expected_sql)
 
     def test_add_error_to_db(self):
         # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
         mock_conn = mock.MagicMock()
-        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
 
         db.add_error_to_db(mock_engine, "test_workbook.xlsx", "Parsing error")
 
@@ -116,36 +123,31 @@ class TestDatabaseEngine(unittest.TestCase):
 
     def test_add_accession_ids_to_db(self):
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
         accession_ids = {"uid_12345": "SCV000012345", "uid_67890": "SCV000067890"}
 
         db.add_accession_ids_to_db(accession_ids, mock_engine)
 
-        # Check that execute was called twice
-        self.assertEqual(mock_engine.execute.call_count, 2)
+        # Should be called once (batch)
+        self.assertEqual(mock_conn.execute.call_count, 1)
 
-        # Check the parameters of each call
-        calls = mock_engine.execute.call_args_list
-
-        # Extract the parameters from each call
-        call_params = [
-            call[0][1] for call in calls
-        ]  # Get the second argument (params dict)
-
-        expected_params = [
+        # Get the parameters passed to execute
+        params = mock_conn.execute.call_args[0][1]
+        expected = [
             {"accession": "SCV000012345", "local_id": "uid_12345"},
             {"accession": "SCV000067890", "local_id": "uid_67890"},
         ]
-
-        # Check that both sets of parameters were used
-        for expected in expected_params:
-            self.assertIn(expected, call_params)
+        # assert that params is a list of dicts with expected content
+        assert len(params) == len(expected)
+        assert all(param in params for param in expected)
 
     @mock.patch("utils.database_actions.text")
     def test_add_clinvar_submission_error_to_db(self, mock_text):
         # Prepare mock engine and connection
         mock_engine = mock.MagicMock()
         mock_conn = mock.MagicMock()
-        mock_engine.connect.return_value.__enter__.return_value = mock_conn
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
 
         errors = {
             "uid_12345": "This record is submitted as novel but it should be submitted as an update",
@@ -155,19 +157,12 @@ class TestDatabaseEngine(unittest.TestCase):
         # Call the function
         db.add_clinvar_submission_error_to_db(errors, mock_engine)
 
-        # Check that execute was called for each error
-        expected_calls = [
-            call(
-                mock_text.return_value,
-                {"error": errors["uid_12345"], "local_id": "uid_12345"},
-            ),
-            call(
-                mock_text.return_value,
-                {"error": errors["uid_67890"], "local_id": "uid_67890"},
-            ),
+        # Check that execute was called once with a list of error dicts
+        expected_params = [
+            {"error": errors["uid_12345"], "local_id": "uid_12345"},
+            {"error": errors["uid_67890"], "local_id": "uid_67890"},
         ]
-        assert mock_conn.execute.call_count == 2
-        mock_conn.execute.assert_has_calls(expected_calls, any_order=True)
+        mock_conn.execute.assert_called_once_with(mock_text.return_value, expected_params)
 
 
 class TestDatabasePandas(unittest.TestCase):
@@ -200,9 +195,11 @@ class TestDatabasePandas(unittest.TestCase):
     @mock.patch("pandas.DataFrame.to_sql")
     def test_add_variants_to_db(self, pd_to_sql_mock):
         mock_engine = mock.MagicMock()
+        mock_conn = mock.MagicMock()
+        mock_engine.begin.return_value.__enter__.return_value = mock_conn
         db.add_variants_to_db(self.df, mock_engine)
         pd_to_sql_mock.assert_called_once_with(
-            "inca", mock_engine, if_exists="append", schema="testdirectory", index=False
+            "inca", mock_conn, if_exists="append", schema="testdirectory", index=False
         )
 
     @mock.patch("pandas.read_sql")

--- a/tests/test_database_actions.py
+++ b/tests/test_database_actions.py
@@ -1,5 +1,6 @@
 import unittest
 import unittest.mock as mock
+from unittest.mock import ANY
 from unittest.mock import call
 from freezegun import freeze_time
 import utils.database_actions as db
@@ -13,6 +14,22 @@ class TestDatabaseEngine(unittest.TestCase):
     '''
     variants = ['uid_12345', 'uid_67890']
 
+    # @freeze_time("2024-07-10 22:22:22")
+    # def test_add_wb_to_db(self):
+    #     '''
+    #     Test that add_wb_to_db is called with the expected SQL when given
+    #     example inputs
+    #     '''
+    #     mock_engine = mock.MagicMock()
+    #     expected_sql = (
+    #         "INSERT INTO testdirectory.inca_workbooks "
+    #         "(workbook_name, date, parse_status) "
+    #         "VALUES ('test_workbook.xlsx', '2024-07-10 22:22:22', FAIL) "
+    #         "ON CONFLICT (workbook_name) DO NOTHING"
+    #     )
+    #     db.add_wb_to_db('test_workbook.xlsx', 'FAIL', mock_engine)
+    #     mock_engine.execute.assert_called_once_with(expected_sql)
+
     @freeze_time("2024-07-10 22:22:22")
     def test_add_wb_to_db(self):
         '''
@@ -20,23 +37,46 @@ class TestDatabaseEngine(unittest.TestCase):
         example inputs
         '''
         mock_engine = mock.MagicMock()
-        expected_sql = (
-            "INSERT INTO testdirectory.inca_workbooks "
-            "(workbook_name, date, parse_status) "
-            "VALUES ('test_workbook.xlsx', '2024-07-10 22:22:22', FAIL) "
-            "ON CONFLICT (workbook_name) DO NOTHING"
+
+        expected_call = call(
+            ANY,
+            {"wb": 'test_workbook.xlsx', "date": mock.ANY, "status": 'FAIL'}
         )
+
         db.add_wb_to_db('test_workbook.xlsx', 'FAIL', mock_engine)
-        mock_engine.execute.assert_called_once_with(expected_sql)
+        mock_engine.execute.assert_called_once_with(
+            mock.ANY,
+            {"wb": 'test_workbook.xlsx', "date": mock.ANY, "status": 'FAIL'}
+        )
+        # Check expected call was made
+        self.assertIn(expected_call, mock_engine.execute.call_args_list)
 
     def test_update_db_for_parsed_wb(self):
         mock_engine = mock.MagicMock()
-        expected_sql = (
-            "UPDATE testdirectory.inca_workbooks SET parse_status = TRUE "
-            "WHERE workbook_name = 'test_workbook.xlsx'"
-        )
+
         db.update_db_for_parsed_wb('test_workbook.xlsx', mock_engine)
-        mock_engine.execute.assert_called_once_with(expected_sql)
+
+        # Check that execute was called once
+        mock_engine.execute.assert_called_once()
+
+        # Get the call arguments
+        call_args = mock_engine.execute.call_args
+        sql_text_obj = call_args[0][0]  # First argument (the text object)
+        params = call_args[0][1]        # Second argument (the parameters dict)
+
+        # Convert text object to string to check SQL content
+        actual_sql = str(sql_text_obj)
+
+        with self.subTest("SQL contains expected UPDATE statement"):
+            self.assertIn("UPDATE testdirectory.inca_workbooks", actual_sql)
+            self.assertIn("SET parse_status = TRUE", actual_sql)
+            self.assertIn("WHERE workbook_name = :wb", actual_sql)
+
+        with self.subTest("Parameters are correct"):
+            expected_params = {
+                'wb': 'test_workbook.xlsx'
+            }
+            self.assertEqual(params, expected_params)
 
     def test_add_submission_id_to_db_if_submission_id_returned(self):
         mock_engine = mock.MagicMock()
@@ -60,13 +100,32 @@ class TestDatabaseEngine(unittest.TestCase):
 
     def test_add_error_to_db(self):
         mock_engine = mock.MagicMock()
-        expected_sql = (
-            "UPDATE testdirectory.inca_workbooks SET parse_status = FALSE, "
-            "comment = 'Parsing error' WHERE workbook_name = "
-            "'test_workbook.xlsx'"
-        )
+
         db.add_error_to_db(mock_engine, 'test_workbook.xlsx', 'Parsing error')
-        mock_engine.execute.assert_called_once_with(expected_sql)
+
+        # Check that execute was called once
+        mock_engine.execute.assert_called_once()
+
+        # Get the call arguments
+        call_args = mock_engine.execute.call_args
+        sql_text_obj = call_args[0][0]  # First argument (the text object)
+        params = call_args[0][1]        # Second argument (the parameters dict)
+
+        # Convert text object to string to check SQL content
+        actual_sql = str(sql_text_obj)
+
+        with self.subTest("SQL contains expected UPDATE statement"):
+            self.assertIn("UPDATE testdirectory.inca_workbooks", actual_sql)
+            self.assertIn("SET parse_status = FALSE", actual_sql)
+            self.assertIn("comment = :err", actual_sql)
+            self.assertIn("WHERE workbook_name = :wb", actual_sql)
+
+        with self.subTest("Parameters are correct"):
+            expected_params = {
+                'err': 'Parsing error',
+                'wb': 'test_workbook.xlsx'
+            }
+            self.assertEqual(params, expected_params)
 
     def test_add_accession_ids_to_db(self):
         mock_engine = mock.MagicMock()
@@ -74,24 +133,30 @@ class TestDatabaseEngine(unittest.TestCase):
             'uid_12345': 'SCV000012345',
             'uid_67890': 'SCV000067890'
         }
-        uid_12345_sql = (
-           "UPDATE testdirectory.inca SET accession_id = 'SCV000012345' "
-           "WHERE local_id = 'uid_12345'"
-        )
-        uid_67890_sql = (
-           "UPDATE testdirectory.inca SET accession_id = 'SCV000067890' "
-           "WHERE local_id = 'uid_67890'"
-        )
+
         db.add_accession_ids_to_db(accession_ids, mock_engine)
 
-        with self.subTest("Assert called twice if two accession IDs to add"):
-            assert mock_engine.execute.call_count == 2
+        # Check that execute was called twice
+        self.assertEqual(mock_engine.execute.call_count, 2)
 
-        mock_engine.execute.assert_has_calls(
-            [call(uid_12345_sql), call(uid_67890_sql)], any_order=True
-        )
+        # Check the parameters of each call
+        calls = mock_engine.execute.call_args_list
+
+        # Extract the parameters from each call
+        call_params = [call[0][1] for call in calls]  # Get the second argument (params dict)
+
+        expected_params = [
+            {'accession': 'SCV000012345', 'local_id': 'uid_12345'},
+            {'accession': 'SCV000067890', 'local_id': 'uid_67890'}
+        ]
+
+        # Check that both sets of parameters were used
+        for expected in expected_params:
+            self.assertIn(expected, call_params)
+
 
     def test_add_clinvar_submission_error_to_db(self):
+
         mock_engine = mock.MagicMock()
         errors = {
             'uid_12345': 'This record is submitted as novel but it should be '
@@ -99,24 +164,16 @@ class TestDatabaseEngine(unittest.TestCase):
             'uid_67890': 'The identifier you provided (MONDO:MONDO:0000) '
             'cannot be validated'
         }
-        uid_12345_sql = (
-           "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: This record"
-           " is submitted as novel but it should be submitted as an update' "
-           "WHERE local_id = 'uid_12345'"
-        )
-        uid_67890_sql = (
-           "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: The "
-           "identifier you provided (MONDO:MONDO:0000) cannot be validated' "
-           "WHERE local_id = 'uid_67890'"
-        )
+
+        expected_calls = [
+            call(ANY, {'error': 'This record is submitted as novel but it should be submitted as an update', 'local_id': 'uid_12345'}),
+            call(ANY, {'error': 'The identifier you provided (MONDO:MONDO:0000) cannot be validated', 'local_id': 'uid_67890'}),
+        ]
+
         db.add_clinvar_submission_error_to_db(errors, mock_engine)
 
-        with self.subTest("Assert called twice if two errors"):
-            assert mock_engine.execute.call_count == 2
-
-        mock_engine.execute.assert_has_calls(
-            [call(uid_12345_sql), call(uid_67890_sql)], any_order=True
-        )
+        assert mock_engine.execute.call_count == 2
+        mock_engine.execute.assert_has_calls(expected_calls, any_order=True)
 
 
 class TestDatabasePandas(unittest.TestCase):
@@ -156,18 +213,60 @@ class TestDatabasePandas(unittest.TestCase):
     def test_select_variants_from_db(self, pd_read_sql_mock):
         mock_engine = mock.MagicMock()
         pd_read_sql_mock.return_value = self.df
-        expected_sql = (
-            "SELECT * FROM testdirectory.inca WHERE interpreted = 'yes' AND "
-            "submission_id is NOT NULL AND accession_id is NULL AND "
-            "organisation_id = '1234'"
-        )
+
         return_df = db.select_variants_from_db(1234, mock_engine, 'NOT NULL')
 
         with self.subTest("Returns value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, self.df)
 
-        with self.subTest("pd.read_sql() called with correct SQL query"):
-            pd_read_sql_mock.assert_called_once_with(expected_sql, mock_engine)
+        with self.subTest("pd.read_sql() called with text object and params"):
+            # Check that pd.read_sql was called with a text object and params
+            self.assertEqual(pd_read_sql_mock.call_count, 1)
+            call_args = pd_read_sql_mock.call_args
+            # First arg should be a text object, second should be engine, third should be params
+            self.assertEqual(len(call_args[0]), 2)  # Two positional args
+            self.assertIn('params', call_args[1])  # params as keyword arg
+            self.assertEqual(call_args[1]['params'], {'org_id': 1234})
+
+
+    def assertSQLContains(self, mock_call, expected_fragments, expected_params=None):
+        """Helper method to assert SQL content and parameters"""
+        call_args = mock_call.call_args
+
+        # Get SQL text
+        sql_text_obj = call_args[0][0]
+        actual_sql = str(sql_text_obj)
+
+        print(f"Actual SQL: {actual_sql}")
+
+        # Check SQL fragments
+        for fragment in expected_fragments:
+            self.assertIn(fragment, actual_sql)
+
+        # Check parameters if provided
+        if expected_params:
+            params = call_args[1].get('params', {})
+            for key, value in expected_params.items():
+                self.assertEqual(params[key], value)
+
+    @mock.patch('pandas.read_sql')
+    def test_select_variants_from_db_with_sql_check(self, pd_read_sql_mock):
+        mock_engine = mock.MagicMock()
+        pd_read_sql_mock.return_value = self.df
+
+        return_df = db.select_variants_from_db(1234, mock_engine, 'NOT NULL')
+
+        # Use helper to check SQL
+        expected_fragments = [
+            "SELECT * FROM testdirectory.inca",
+            "WHERE interpreted = 'yes'",
+            "submission_id IS NOT NULL",
+            "organisation_id = :org_id",
+            "allele_origin = 'germline'"
+        ]
+        expected_params = {'org_id': 1234}
+
+        self.assertSQLContains(pd_read_sql_mock, expected_fragments, expected_params)
 
     @mock.patch('pandas.read_sql')
     def test_select_variants_from_db_with_exclude(self, pd_read_sql_mock):
@@ -178,11 +277,7 @@ class TestDatabasePandas(unittest.TestCase):
         mock_engine = mock.MagicMock()
         exclude = " AND panel != '_HGNC:7527'"
         pd_read_sql_mock.return_value = self.df
-        expected_sql = (
-            "SELECT * FROM testdirectory.inca WHERE interpreted = 'yes' AND "
-            "submission_id is NULL AND accession_id is NULL AND "
-            "organisation_id = '1234' AND panel != '_HGNC:7527'"
-        )
+
         return_df = db.select_variants_from_db(
             1234, mock_engine, 'NULL', exclude
         )
@@ -190,16 +285,25 @@ class TestDatabasePandas(unittest.TestCase):
         with self.subTest("Returns mocked value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, self.df)
 
-        with self.subTest("pd.read_sql() called with correct SQL query"):
-            pd_read_sql_mock.assert_called_once_with(expected_sql, mock_engine)
+        with self.subTest("pd.read_sql() called with text object and params"):
+            # Check that pd.read_sql was called with a text object and params
+            self.assertEqual(pd_read_sql_mock.call_count, 1)
+            call_args = pd_read_sql_mock.call_args
+            # Check that exclude parameter was included by inspecting the SQL string
+            sql_text = str(call_args[0][0])  # Convert text object to string
+            self.assertIn("SELECT * FROM testdirectory.inca", sql_text)
+            self.assertIn("WHERE interpreted = 'yes'", sql_text)
+            self.assertIn("submission_id IS NULL", sql_text)
+            self.assertIn("organisation_id = :org_id", sql_text)
+            self.assertIn("allele_origin = 'germline'", sql_text)
+            self.assertIn("panel != '_HGNC:7527'", sql_text)  # The exclude part
+
+            self.assertEqual(call_args[1]['params'], {'org_id': 1234})
+
 
     @mock.patch('pandas.read_sql')
     def test_select_wb_from_db(self, pd_read_sql_mock):
         mock_engine = mock.MagicMock()
-        expected_sql = (
-            "SELECT * FROM testdirectory.inca_workbooks WHERE parse_status = "
-            "FALSE"
-        )
         data = {
             "workbook_name": ['test_wb.xlsx'],
             "parse_status": False
@@ -210,8 +314,16 @@ class TestDatabasePandas(unittest.TestCase):
         return_df = db.select_workbooks_from_db(
             mock_engine, "parse_status = FALSE"
         )
+
         with self.subTest("Returns mocked value from pd.read_sql()"):
             pd.testing.assert_frame_equal(return_df, df)
 
-        with self.subTest("pd.read_sql() called with correct SQL query"):
-            pd_read_sql_mock.assert_called_once_with(expected_sql, mock_engine)
+        with self.subTest("pd.read_sql() called with text object"):
+            # Check that pd.read_sql was called with a text object
+            self.assertEqual(pd_read_sql_mock.call_count, 1)
+            call_args = pd_read_sql_mock.call_args
+            # Should be called with text object and engine
+            self.assertEqual(len(call_args[0]), 2)
+            # Check the SQL contains our parameter
+            sql_text = str(call_args[0][0])
+            self.assertIn("parse_status = FALSE", sql_text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,11 +54,6 @@ def parsed_wb():
     )
     return parsed_wb
 
-def test_get_summary_fields_org_error(parsed_wb, mock_config):
-
-    df, err = utils.get_summary_fields(parsed_wb, mock_config, "BADORG")
-    assert "Organisation must be CUH or NUH" in err
-
 
 def test_check_interpret_table_valid():
     config = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,139 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import MagicMock, patch
+from utils import utils
+from datetime import date
+import openpyxl
+
+# --- 40-78: get_workbook_data ---
+
+@pytest.fixture
+def mock_workbook():
+    wb = MagicMock()
+    wb.__getitem__.side_effect = lambda x: {
+        "summary": {
+            "B1": MagicMock(value="123456789-12345A1234-12ABCDE1-1234-X-PS1"),
+            "F1": MagicMock(value="1234_Condition"),
+            "F2": MagicMock(value="Panel1"),
+            "G22": MagicMock(value=None),
+            "A": [MagicMock(value="Reference:", row=10), MagicMock(value=None, row=11)],
+            "C38": MagicMock(value=1)
+        }
+    }[x]
+    wb.sheetnames = ["summary", "interpret1"]
+    return wb
+
+@pytest.fixture
+def mock_config():
+    return {
+        "Institution": "TestInst",
+        "Collection method": "TestColl",
+        "Allele origin": "TestAllele",
+        "Affected status": "TestStatus",
+        "CUH Organisation": "CUH Org",
+        "CUH org ID": "CUH123",
+        "NUH Organisation": "NUH Org",
+        "NUH org ID": "NUH123",
+        "field_cells": [("germline_classification", "B26"), ("hgvsc", "B27")],
+        "acgs_criteria": [],
+        "matched_strength": {},
+        "strength_dropdown": [],
+        "BA1_dropdown": [],
+    }
+
+@pytest.fixture
+def mock_engine():
+    return MagicMock()
+
+@pytest.fixture
+def parsed_wb():
+    # import xlsx file from tests/test_data/NUH/nuh.xlsx
+    parsed_wb = openpyxl.load_workbook(
+        "tests/test_data/NUH/nuh.xlsx"
+    )
+    return parsed_wb
+
+def test_get_summary_fields_org_error(parsed_wb, mock_config):
+
+    df, err = utils.get_summary_fields(parsed_wb, mock_config, "BADORG")
+    assert "Organisation must be CUH or NUH" in err
+
+
+def test_check_interpret_table_valid():
+    config = {
+        "strength_dropdown": ["Strong", "Supporting"],
+        "BA1_dropdown": ["Yes", "No"],
+        "acgs_criteria": [],
+    }
+    df_interpret = pd.DataFrame({
+        "germline_classification": ["Pathogenic"],
+        "hgvsc": ["NM_1"],
+        "ba1": [np.nan]
+    })
+    df_included = pd.DataFrame({"hgvsc": ["NM_1"]})
+    assert utils.check_interpret_table(df_interpret, df_included, config) is None
+
+def test_check_interpret_table_invalid():
+    config = {
+        "strength_dropdown": ["Strong", "Supporting"],
+        "BA1_dropdown": ["Yes", "No"],
+        "acgs_criteria": [],
+    }
+    df_interpret = pd.DataFrame({
+        "germline_classification": [np.nan],
+        "hgvsc": ["NM_1"],
+        "ba1": [np.nan]
+    })
+    df_included = pd.DataFrame({"hgvsc": ["NM_1"]})
+    err = utils.check_interpret_table(df_interpret, df_included, config)
+    assert "empty ACMG classification" in err
+
+def test_check_interpreted_col_invalid_value():
+    df = pd.DataFrame({
+        "interpreted": ["yes", "maybe"],
+        "germline_classification": ["Pathogenic", None],
+        "hgvsc": ["NM_1", "NM_2"]
+    })
+    err = utils.check_interpreted_col(df)
+    assert "not all either 'yes' or 'no'" in err
+
+
+def test_check_sample_name_error():
+    err = utils.check_sample_name("bad", "bad", "bad", "bad", "bad")
+    assert err is not None
+
+@patch("utils.utils.requests.get")
+def test_submission_status_check_success(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content.decode.return_value = '{"actions":[{"status":"done","responses":[{"files":[{"url":"http://file"}]}]}]}'
+    mock_response.headers = {}
+    mock_get.return_value = mock_response
+
+    mock_file_response = MagicMock()
+    mock_file_response.status_code = 200
+    mock_file_response.content.decode.return_value = '{"file":"content"}'
+    mock_get.side_effect = [mock_response, mock_file_response]
+
+    status, status_response = utils.submission_status_check("subid", {}, "http://api")
+    assert status == "done"
+    assert "file" in status_response
+
+@patch("utils.utils.requests.get")
+def test_submission_status_check_fail(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.content.decode.return_value = "fail"
+    mock_response.headers = {}
+    mock_get.return_value = mock_response
+    with pytest.raises(RuntimeError):
+        utils.submission_status_check("subid", {}, "http://api")
+
+def test_check_sample_name_valid():
+    err = utils.check_sample_name("123456789", "12345A1234", "12ABCDE1", "1234", "PS1")
+    assert err is None
+
+def test_check_sample_name_invalid_probeset():
+    err = utils.check_sample_name("123456789", "12345A1234", "12ABCDE1", "1234", "A"*21)
+    assert "too long/short" in err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ import pandas as pd
 import numpy as np
 from unittest.mock import MagicMock, patch
 from utils import utils
-from datetime import date
 import openpyxl
 
 # --- 40-78: get_workbook_data ---

--- a/tests/test_workbook_parsing.py
+++ b/tests/test_workbook_parsing.py
@@ -23,6 +23,7 @@ for wb in nuh_workbooks + cuh_workbooks:
     locals()[filename] = wb
 
 
+
 class TestParsing(unittest.TestCase):
     cuh_workbook = load_workbook(cuh)
     nuh_workbook = load_workbook(nuh)
@@ -344,8 +345,7 @@ class TestParsing(unittest.TestCase):
         Test if the "Date last evaluated" is pd date time format
         """
         df, msg = utils.get_summary_fields(self.nuh_workbook, config, "NUH")
-        print(df)
-        print(df.columns)
+
         with self.subTest("df has expected number of rows"):
             assert df.shape[0] == 1
 
@@ -367,42 +367,6 @@ class TestParsing(unittest.TestCase):
                 pd._libs.tslibs.timestamps.Timestamp
             )
 
-    def test_get_summary_fields_lowercase_org(self):
-        """
-        Tests all the following with providing
-        lowercase organisation name (nuh).
-
-        Test "get_summary_fields" generates df with expected shape
-        (1 row and 15 columns in test case)
-        Test the "Preferred condition name" is split as expected
-        (Tuberous sclerosis in test case)
-        Test if the "Ref genome" is correctly extracted
-        (GRCh37.p13 in test case)
-        Test if the "Date last evaluated" is pd date time format
-        """
-        df, msg = utils.get_summary_fields(self.nuh_workbook, config, "nuh")
-        print(df)
-        print(df.columns)
-        with self.subTest("df has expected number of rows"):
-            assert df.shape[0] == 1
-
-        with self.subTest("df has expected number of columns"):
-            assert df.shape[1] == 16
-
-        with self.subTest("correct preferred condition name extracted"):
-            assert df["preferred_condition_name"][0] == (
-                "Inherited breast cancer and ovarian cancer;Inherited breast "
-                "cancer and ovarian cancer"
-            )
-
-        with self.subTest("Ref genome correctly extracted"):
-            assert df["ref_genome"][0] == "GRCh37.p13"
-
-        with self.subTest("Vale for date_last_evaluated is date type"):
-            assert isinstance(
-                df["date_last_evaluated"][0],
-                pd._libs.tslibs.timestamps.Timestamp
-            )
 
     @freeze_time("2024-07-10 22:22:22")
     def test_no_evaluated_date(self):

--- a/tests/test_workbook_parsing.py
+++ b/tests/test_workbook_parsing.py
@@ -1,20 +1,22 @@
 import glob
-import os
 import json
-from utils import utils
-import pandas as pd
-from pathlib import Path
+import os
 import unittest
-from openpyxl import load_workbook
-from freezegun import freeze_time
+from pathlib import Path
+
 import numpy as np
+import pandas as pd
+from freezegun import freeze_time
+from openpyxl import load_workbook
+
+from utils import utils
 
 TEST_DATA_DIR = f"{Path(__file__).parent.resolve()}/test_data"
 
-nuh_workbooks = glob.glob(TEST_DATA_DIR + '/NUH/' + "*.xlsx")
-cuh_workbooks = glob.glob(TEST_DATA_DIR + '/CUH/' + "*.xlsx")
+nuh_workbooks = glob.glob(TEST_DATA_DIR + "/NUH/" + "*.xlsx")
+cuh_workbooks = glob.glob(TEST_DATA_DIR + "/CUH/" + "*.xlsx")
 
-with open(TEST_DATA_DIR + '/test_config.json') as f:
+with open(TEST_DATA_DIR + "/test_config.json") as f:
     config = json.load(f)
 
 
@@ -29,8 +31,12 @@ class TestParsing(unittest.TestCase):
         # Load 2 example cuh/nuh workbooks and dataframes for use in tests
         cls.cuh_workbook = load_workbook(cls.workbook_paths["cuh"])
         cls.nuh_workbook = load_workbook(cls.workbook_paths["nuh"])
-        cls.cuh_df_included = utils.get_included_fields(cls.cuh_workbook, cls.workbook_paths["cuh"])
-        cls.cuh_df_report, cls.cuh_msg = utils.get_report_fields(cls.cuh_workbook, config, cls.cuh_df_included)
+        cls.cuh_df_included = utils.get_included_fields(
+            cls.cuh_workbook, cls.workbook_paths["cuh"]
+        )
+        cls.cuh_df_report, cls.cuh_msg = utils.get_report_fields(
+            cls.cuh_workbook, config, cls.cuh_df_included
+        )
 
     def test_get_folder(self):
         """
@@ -98,12 +104,13 @@ class TestParsing(unittest.TestCase):
         with self.subTest("consequence extracted correctly"):
             assert list(df["consequence"]) == [
                 "intron_variant&splice_polypyrimidine_tract_variant&splice_region_variant",
-                "stop_gained"
+                "stop_gained",
             ]
 
         with self.subTest("HGVSc extracted correctly"):
             assert list(df["hgvsc"]) == [
-                "NM_000368.5:c.2626-5_2626-4dup", "NM_000548.5:c.4255C>T"
+                "NM_000368.5:c.2626-5_2626-4dup",
+                "NM_000548.5:c.4255C>T",
             ]
 
     def test_get_report_fields(self):
@@ -132,58 +139,58 @@ class TestParsing(unittest.TestCase):
                 "prevalence",
                 "hgvsc",
                 "germline_classification",
-                'pvs1',
-                'pvs1_evidence',
-                'ps1',
-                'ps1_evidence',
-                'ps2',
-                'ps2_evidence',
-                'ps3',
-                'ps3_evidence',
-                'ps4',
-                'ps4_evidence',
-                'pm1',
-                'pm1_evidence',
-                'pm2',
-                'pm2_evidence',
-                'pm3',
-                'pm3_evidence',
-                'pm4',
-                'pm4_evidence',
-                'pm5',
-                'pm5_evidence',
-                'pm6',
-                'pm6_evidence',
-                'pp1',
-                'pp1_evidence',
-                'pp2',
-                'pp2_evidence',
-                'pp3',
-                'pp3_evidence',
-                'pp4',
-                'pp4_evidence',
-                'bs1',
-                'bs1_evidence',
-                'bs2',
-                'bs2_evidence',
-                'bs3',
-                'bs3_evidence',
-                'ba1',
-                'ba1_evidence',
-                'bp2',
-                'bp2_evidence',
-                'bp3',
-                'bp3_evidence',
-                'bs4',
-                'bs4_evidence',
-                'bp1',
-                'bp1_evidence',
-                'bp4',
-                'bp4_evidence',
-                'bp5',
-                'bp5_evidence',
-                'bp7',
-                'bp7_evidence',
+                "pvs1",
+                "pvs1_evidence",
+                "ps1",
+                "ps1_evidence",
+                "ps2",
+                "ps2_evidence",
+                "ps3",
+                "ps3_evidence",
+                "ps4",
+                "ps4_evidence",
+                "pm1",
+                "pm1_evidence",
+                "pm2",
+                "pm2_evidence",
+                "pm3",
+                "pm3_evidence",
+                "pm4",
+                "pm4_evidence",
+                "pm5",
+                "pm5_evidence",
+                "pm6",
+                "pm6_evidence",
+                "pp1",
+                "pp1_evidence",
+                "pp2",
+                "pp2_evidence",
+                "pp3",
+                "pp3_evidence",
+                "pp4",
+                "pp4_evidence",
+                "bs1",
+                "bs1_evidence",
+                "bs2",
+                "bs2_evidence",
+                "bs3",
+                "bs3_evidence",
+                "ba1",
+                "ba1_evidence",
+                "bp2",
+                "bp2_evidence",
+                "bp3",
+                "bp3_evidence",
+                "bs4",
+                "bs4_evidence",
+                "bp1",
+                "bp1_evidence",
+                "bp4",
+                "bp4_evidence",
+                "bp5",
+                "bp5_evidence",
+                "bp7",
+                "bp7_evidence",
                 "comment_on_classification",
             ]
 
@@ -204,10 +211,10 @@ class TestParsing(unittest.TestCase):
 
         with self.subTest("pvs1 evidence extracted correctly"):
             assert df["pvs1_evidence"][0] == (
-                    "Exon present in all transcripts on gnomAD. "
-                    "LOF known mechanism of disease. "
-                    "Predicted to undergo nonsense-mediated decay."
-                )
+                "Exon present in all transcripts on gnomAD. "
+                "LOF known mechanism of disease. "
+                "Predicted to undergo nonsense-mediated decay."
+            )
 
         with self.subTest("ps4 evidence extracted correctly"):
             assert df["ps4_evidence"][0] == (
@@ -234,13 +241,11 @@ class TestParsing(unittest.TestCase):
             assert pd.isna(df["pp1_evidence"][0])
 
         with self.subTest("No error message should be returned"):
-            assert self.msg is None
+            assert self.cuh_msg is None
 
     def test_check_interpret_table_returns_no_error_if_hgvsc_matches(self):
         error_msg = utils.check_interpret_table(
-            self.cuh_df_report,
-            self.cuh_df_included,
-            config
+            self.cuh_df_report, self.cuh_df_included, config
         )
         assert error_msg is None
 
@@ -252,14 +257,9 @@ class TestParsing(unittest.TestCase):
         df_report, msg = utils.get_report_fields(
             wrong_hgvsc_workbook, config, df_include
         )
-        error_msg = utils.check_interpret_table(
-            df_report,
-            df_include,
-            config
-        )
+        error_msg = utils.check_interpret_table(df_report, df_include, config)
         assert error_msg == (
-            "HGVSc in interpret table does not match with that in included "
-            "sheet"
+            "HGVSc in interpret table does not match with that in included sheet"
         )
 
     def test_check_interpret_table_error_if_hgvsc_empty(self):
@@ -270,11 +270,7 @@ class TestParsing(unittest.TestCase):
         df_report, msg = utils.get_report_fields(
             empty_hgvsc_workbook, config, df_include
         )
-        error_msg = utils.check_interpret_table(
-            df_report,
-            df_include,
-            config
-        )
+        error_msg = utils.check_interpret_table(df_report, df_include, config)
         assert error_msg == "empty HGVSc in interpret table"
 
     def test_check_interpret_table_error_if_no_acmg_classification(self):
@@ -282,14 +278,8 @@ class TestParsing(unittest.TestCase):
         df_include = utils.get_included_fields(
             no_acmg_workbook, self.workbook_paths["cuh_empty_acmg"]
         )
-        df_report, msg = utils.get_report_fields(
-            no_acmg_workbook, config, df_include
-        )
-        error_msg = utils.check_interpret_table(
-            df_report,
-            df_include,
-            config
-        )
+        df_report, msg = utils.get_report_fields(no_acmg_workbook, config, df_include)
+        error_msg = utils.check_interpret_table(df_report, df_include, config)
         assert error_msg == "empty ACMG classification in interpret table"
 
     def test_check_interpret_table_error_if_wrong_acmg_classification(self):
@@ -300,11 +290,7 @@ class TestParsing(unittest.TestCase):
         df_report, msg = utils.get_report_fields(
             wrong_acmg_workbook, config, df_include
         )
-        error_msg = utils.check_interpret_table(
-            df_report,
-            df_include,
-            config
-        )
+        error_msg = utils.check_interpret_table(df_report, df_include, config)
         assert error_msg == "wrong ACMG classification in interpret table"
 
     def test_check_interpret_table_error_if_wrong_strength(self):
@@ -312,16 +298,13 @@ class TestParsing(unittest.TestCase):
             self.workbook_paths["nuh_wrong_interpret_strength"]
         )
         df_include = utils.get_included_fields(
-            wrong_interpret_strength_workbook, self.workbook_paths["nuh_wrong_interpret_strength"]
+            wrong_interpret_strength_workbook,
+            self.workbook_paths["nuh_wrong_interpret_strength"],
         )
         df_report, msg = utils.get_report_fields(
             wrong_interpret_strength_workbook, config, df_include
         )
-        error_msg = utils.check_interpret_table(
-            df_report,
-            df_include,
-            config
-        )
+        error_msg = utils.check_interpret_table(df_report, df_include, config)
         assert error_msg == "Wrong strength in pm2"
 
     def test_checking_sheet_wrong_summary(self):
@@ -330,7 +313,9 @@ class TestParsing(unittest.TestCase):
         assert msg == "extra col(s) added or change(s) done in summary sheet"
 
     def test_checking_sheet_wrong_interpret_row(self):
-        wrong_interpret_row = load_workbook(self.workbook_paths["nuh_wrong_interpret_row"])
+        wrong_interpret_row = load_workbook(
+            self.workbook_paths["nuh_wrong_interpret_row"]
+        )
         msg = utils.checking_sheets(wrong_interpret_row)
         assert msg == (
             "extra row(s) or col(s) added or change(s) done in interpret sheet"
@@ -365,43 +350,39 @@ class TestParsing(unittest.TestCase):
 
         with self.subTest("Vale for date_last_evaluated is date type"):
             assert isinstance(
-                df["date_last_evaluated"][0],
-                pd._libs.tslibs.timestamps.Timestamp
+                df["date_last_evaluated"][0], pd._libs.tslibs.timestamps.Timestamp
             )
-
 
     @freeze_time("2024-07-10 22:22:22")
     def test_no_evaluated_date(self):
-        '''
+        """
         Test that when there is no date last evaluated, today's date is used.
         Expect the time to change to 00:00 as we are only using date not time.
         This test uses an example workbook with nothing in the date cell
-        '''
+        """
         nuh_no_evaluated_date = self.workbook_paths["nuh_no_evaluated_date"]
         no_evaluated_date_workbook = load_workbook(nuh_no_evaluated_date)
         df, msg = utils.get_summary_fields(
             no_evaluated_date_workbook, config, nuh_no_evaluated_date
         )
-        assert str(df['date_last_evaluated'].item()) == "2024-07-10 00:00:00"
+        assert str(df["date_last_evaluated"].item()) == "2024-07-10 00:00:00"
 
     def test_error_message_if_date_last_evaluated_invalid(self):
-        '''
+        """
         Test that if the workbook has an evaluation date that is not compatible
         with datetime i.e. is not a date, the correct error message is returned
         which will cause this workbook to be skipped and added to parsing
         failed list.
         This test uses an example workbook with "Not valid" in the date cell
-        '''
+        """
         invalid_evaluation_date_workbook = load_workbook(
             self.workbook_paths["nuh_invalid_evaluated_date"]
         )
         df, msg = utils.get_summary_fields(
-            invalid_evaluation_date_workbook,
-            config,
-            self.workbook_paths["nuh_invalid_evaluated_date"]
+            invalid_evaluation_date_workbook, config, "NUH"
         )
         assert msg == (
-            "Value for date last evaluated \"Not valid\" is not compatible "
+            'Value for date last evaluated "Not valid" is not compatible '
             "with datetime conversion"
         )
 
@@ -410,22 +391,20 @@ class TestParsing(unittest.TestCase):
         Test if interpreted col (yes/no) is correctly filled in no error is
         raised.
         """
-        df_summary, _ = utils.get_summary_fields(
-            self.cuh_workbook, config, self.workbook_paths["cuh"]
-        )
+        df_summary, _ = utils.get_summary_fields(self.cuh_workbook, config, "CUH")
         df_merged = pd.merge(self.cuh_df_included, df_summary, how="cross")
-        df_final = pd.merge(df_merged, self.df_report, on="hgvsc", how="left")
+        df_final = pd.merge(df_merged, self.cuh_df_report, on="hgvsc", how="left")
         msg = utils.check_interpreted_col(df_final)
         assert msg is None
 
     def test_interpreted_col_errors_if_incongruous(self):
-        '''
+        """
         Test that there is a classification for each variant that has been
         interpreted and no classification if not interpreted.
-        '''
+        """
         data = [
-            ['no', 'Pathogenic', 'NM_000368.5:c.2626-5_2626-4dup'],
-            ['yes', np.nan, 'NM_000548.5:c.4255C>T']
+            ["no", "Pathogenic", "NM_000368.5:c.2626-5_2626-4dup"],
+            ["yes", np.nan, "NM_000548.5:c.4255C>T"],
         ]
         df = pd.DataFrame(
             data, columns=["interpreted", "germline_classification", "hgvsc"]
@@ -441,8 +420,8 @@ class TestParsing(unittest.TestCase):
 
     def test_interpreted_col_errors_if_value_neither_yes_or_no(self):
         data = [
-            ['yes', 'Pathogenic', 'NM_000368.5:c.2626-5_2626-4dup'],
-            ['foo', np.nan, 'NM_000548.5:c.4255C>T']
+            ["yes", "Pathogenic", "NM_000368.5:c.2626-5_2626-4dup"],
+            ["foo", np.nan, "NM_000548.5:c.4255C>T"],
         ]
         df = pd.DataFrame(
             data, columns=["interpreted", "germline_classification", "hgvsc"]

--- a/tests/test_workbook_parsing.py
+++ b/tests/test_workbook_parsing.py
@@ -18,17 +18,19 @@ with open(TEST_DATA_DIR + '/test_config.json') as f:
     config = json.load(f)
 
 
-for wb in nuh_workbooks + cuh_workbooks:
-    filename = os.path.basename(wb).strip(".xlsx")
-    locals()[filename] = wb
-
-
-
 class TestParsing(unittest.TestCase):
-    cuh_workbook = load_workbook(cuh)
-    nuh_workbook = load_workbook(nuh)
-    df_included = utils.get_included_fields(cuh_workbook, cuh)
-    df_report, msg = utils.get_report_fields(cuh_workbook, config, df_included)
+    @classmethod
+    def setUpClass(cls):
+        cls.workbook_paths = {}
+        for wb in nuh_workbooks + cuh_workbooks:
+            filename = os.path.basename(wb).removesuffix(".xlsx")
+            cls.workbook_paths[filename] = wb
+
+        # Load 2 example cuh/nuh workbooks and dataframes for use in tests
+        cls.cuh_workbook = load_workbook(cls.workbook_paths["cuh"])
+        cls.nuh_workbook = load_workbook(cls.workbook_paths["nuh"])
+        cls.cuh_df_included = utils.get_included_fields(cls.cuh_workbook, cls.workbook_paths["cuh"])
+        cls.cuh_df_report, cls.cuh_msg = utils.get_report_fields(cls.cuh_workbook, config, cls.cuh_df_included)
 
     def test_get_folder(self):
         """
@@ -36,12 +38,12 @@ class TestParsing(unittest.TestCase):
         where the workbook exists
         """
         with self.subTest("NUH folder correct"):
-            NUH_folder = utils.get_folder_of_input_file(nuh)
+            NUH_folder = utils.get_folder_of_input_file(self.workbook_paths["nuh"])
             assert NUH_folder == "NUH"
 
         with self.subTest("CUH folder correct"):
-            NUH_folder = utils.get_folder_of_input_file(cuh)
-            assert NUH_folder == "CUH"
+            CUH_folder = utils.get_folder_of_input_file(self.workbook_paths["cuh"])
+            assert CUH_folder == "CUH"
 
     def test_get_included_fields(self):
         """
@@ -52,7 +54,7 @@ class TestParsing(unittest.TestCase):
         in lowercase (no,yes in test case)
         Test contents of df and see if they are as expected
         """
-        df = self.df_included
+        df = self.cuh_df_included
 
         with self.subTest("df has two variants, so two rows"):
             assert df.shape[0] == 2
@@ -115,7 +117,7 @@ class TestParsing(unittest.TestCase):
         and evidence columns (some are expected to be np.nan)
         Test there is no error message
         """
-        df = self.df_report
+        df = self.cuh_df_report
 
         with self.subTest("df has one reported variants, so one row"):
             assert df.shape[0] == 1
@@ -236,16 +238,16 @@ class TestParsing(unittest.TestCase):
 
     def test_check_interpret_table_returns_no_error_if_hgvsc_matches(self):
         error_msg = utils.check_interpret_table(
-            self.df_report,
-            self.df_included,
+            self.cuh_df_report,
+            self.cuh_df_included,
             config
         )
         assert error_msg is None
 
     def test_check_interpret_table_error_if_hgvsc_wrong(self):
-        wrong_hgvsc_workbook = load_workbook(cuh_wrong_hgvsc)
+        wrong_hgvsc_workbook = load_workbook(self.workbook_paths["cuh_wrong_hgvsc"])
         df_include = utils.get_included_fields(
-            wrong_hgvsc_workbook, cuh_wrong_hgvsc
+            wrong_hgvsc_workbook, self.workbook_paths["cuh_wrong_hgvsc"]
         )
         df_report, msg = utils.get_report_fields(
             wrong_hgvsc_workbook, config, df_include
@@ -261,9 +263,9 @@ class TestParsing(unittest.TestCase):
         )
 
     def test_check_interpret_table_error_if_hgvsc_empty(self):
-        empty_hgvsc_workbook = load_workbook(cuh_empty_hgvsc)
+        empty_hgvsc_workbook = load_workbook(self.workbook_paths["cuh_empty_hgvsc"])
         df_include = utils.get_included_fields(
-            empty_hgvsc_workbook, cuh_empty_hgvsc
+            empty_hgvsc_workbook, self.workbook_paths["cuh_empty_hgvsc"]
         )
         df_report, msg = utils.get_report_fields(
             empty_hgvsc_workbook, config, df_include
@@ -276,9 +278,9 @@ class TestParsing(unittest.TestCase):
         assert error_msg == "empty HGVSc in interpret table"
 
     def test_check_interpret_table_error_if_no_acmg_classification(self):
-        no_acmg_workbook = load_workbook(cuh_empty_acmg)
+        no_acmg_workbook = load_workbook(self.workbook_paths["cuh_empty_acmg"])
         df_include = utils.get_included_fields(
-            no_acmg_workbook, cuh_empty_acmg
+            no_acmg_workbook, self.workbook_paths["cuh_empty_acmg"]
         )
         df_report, msg = utils.get_report_fields(
             no_acmg_workbook, config, df_include
@@ -291,9 +293,9 @@ class TestParsing(unittest.TestCase):
         assert error_msg == "empty ACMG classification in interpret table"
 
     def test_check_interpret_table_error_if_wrong_acmg_classification(self):
-        wrong_acmg_workbook = load_workbook(cuh_wrong_acmg)
+        wrong_acmg_workbook = load_workbook(self.workbook_paths["cuh_wrong_acmg"])
         df_include = utils.get_included_fields(
-            wrong_acmg_workbook, cuh_wrong_acmg
+            wrong_acmg_workbook, self.workbook_paths["cuh_wrong_acmg"]
         )
         df_report, msg = utils.get_report_fields(
             wrong_acmg_workbook, config, df_include
@@ -307,10 +309,10 @@ class TestParsing(unittest.TestCase):
 
     def test_check_interpret_table_error_if_wrong_strength(self):
         wrong_interpret_strength_workbook = load_workbook(
-            nuh_wrong_interpret_strength
+            self.workbook_paths["nuh_wrong_interpret_strength"]
         )
         df_include = utils.get_included_fields(
-            wrong_interpret_strength_workbook, nuh_wrong_interpret_strength
+            wrong_interpret_strength_workbook, self.workbook_paths["nuh_wrong_interpret_strength"]
         )
         df_report, msg = utils.get_report_fields(
             wrong_interpret_strength_workbook, config, df_include
@@ -323,12 +325,12 @@ class TestParsing(unittest.TestCase):
         assert error_msg == "Wrong strength in pm2"
 
     def test_checking_sheet_wrong_summary(self):
-        wrong_summary_workbook = load_workbook(nuh_wrong_summary)
+        wrong_summary_workbook = load_workbook(self.workbook_paths["nuh_wrong_summary"])
         msg = utils.checking_sheets(wrong_summary_workbook)
         assert msg == "extra col(s) added or change(s) done in summary sheet"
 
     def test_checking_sheet_wrong_interpret_row(self):
-        wrong_interpret_row = load_workbook(nuh_wrong_interpret_row)
+        wrong_interpret_row = load_workbook(self.workbook_paths["nuh_wrong_interpret_row"])
         msg = utils.checking_sheets(wrong_interpret_row)
         assert msg == (
             "extra row(s) or col(s) added or change(s) done in interpret sheet"
@@ -375,6 +377,7 @@ class TestParsing(unittest.TestCase):
         Expect the time to change to 00:00 as we are only using date not time.
         This test uses an example workbook with nothing in the date cell
         '''
+        nuh_no_evaluated_date = self.workbook_paths["nuh_no_evaluated_date"]
         no_evaluated_date_workbook = load_workbook(nuh_no_evaluated_date)
         df, msg = utils.get_summary_fields(
             no_evaluated_date_workbook, config, nuh_no_evaluated_date
@@ -390,12 +393,12 @@ class TestParsing(unittest.TestCase):
         This test uses an example workbook with "Not valid" in the date cell
         '''
         invalid_evaluation_date_workbook = load_workbook(
-            nuh_invalid_evaluated_date
+            self.workbook_paths["nuh_invalid_evaluated_date"]
         )
         df, msg = utils.get_summary_fields(
             invalid_evaluation_date_workbook,
             config,
-            nuh_invalid_evaluated_date
+            self.workbook_paths["nuh_invalid_evaluated_date"]
         )
         assert msg == (
             "Value for date last evaluated \"Not valid\" is not compatible "
@@ -408,9 +411,9 @@ class TestParsing(unittest.TestCase):
         raised.
         """
         df_summary, _ = utils.get_summary_fields(
-            self.cuh_workbook, config, cuh
+            self.cuh_workbook, config, self.workbook_paths["cuh"]
         )
-        df_merged = pd.merge(self.df_included, df_summary, how="cross")
+        df_merged = pd.merge(self.cuh_df_included, df_summary, how="cross")
         df_final = pd.merge(df_merged, self.df_report, on="hgvsc", how="left")
         msg = utils.check_interpreted_col(df_final)
         assert msg is None

--- a/tests/test_workbook_parsing.py
+++ b/tests/test_workbook_parsing.py
@@ -343,8 +343,46 @@ class TestParsing(unittest.TestCase):
         (GRCh37.p13 in test case)
         Test if the "Date last evaluated" is pd date time format
         """
-        df, msg = utils.get_summary_fields(self.nuh_workbook, config, nuh)
+        df, msg = utils.get_summary_fields(self.nuh_workbook, config, "NUH")
+        print(df)
+        print(df.columns)
+        with self.subTest("df has expected number of rows"):
+            assert df.shape[0] == 1
 
+        with self.subTest("df has expected number of columns"):
+            assert df.shape[1] == 16
+
+        with self.subTest("correct preferred condition name extracted"):
+            assert df["preferred_condition_name"][0] == (
+                "Inherited breast cancer and ovarian cancer;Inherited breast "
+                "cancer and ovarian cancer"
+            )
+
+        with self.subTest("Ref genome correctly extracted"):
+            assert df["ref_genome"][0] == "GRCh37.p13"
+
+        with self.subTest("Vale for date_last_evaluated is date type"):
+            assert isinstance(
+                df["date_last_evaluated"][0],
+                pd._libs.tslibs.timestamps.Timestamp
+            )
+
+    def test_get_summary_fields_lowercase_org(self):
+        """
+        Tests all the following with providing
+        lowercase organisation name (nuh).
+
+        Test "get_summary_fields" generates df with expected shape
+        (1 row and 15 columns in test case)
+        Test the "Preferred condition name" is split as expected
+        (Tuberous sclerosis in test case)
+        Test if the "Ref genome" is correctly extracted
+        (GRCh37.p13 in test case)
+        Test if the "Date last evaluated" is pd date time format
+        """
+        df, msg = utils.get_summary_fields(self.nuh_workbook, config, "nuh")
+        print(df)
+        print(df.columns)
         with self.subTest("df has expected number of rows"):
             assert df.shape[0] == 1
 

--- a/utils/clinvar.py
+++ b/utils/clinvar.py
@@ -1,9 +1,7 @@
-import pandas as pd
 import requests
 import json
 from requests.adapters import HTTPAdapter, Retry
-from utils.database_actions import add_clinvar_submission_error_to_db
-from typing import List, Dict, Any, Tuple, Optional
+from typing import List, Dict, Any, Tuple
 
 def extract_clinvar_information(variant_row, ref_genomes: list) -> dict:
     '''
@@ -19,7 +17,7 @@ def extract_clinvar_information(variant_row, ref_genomes: list) -> dict:
 
     assembly = variant_row["ref_genome"].split('.')[0]
 
-    clinvar_dict = {
+    clinvar_dict: dict = {
             'clinicalSignificance': {
                 'clinicalSignificanceDescription': variant_row["germline_classification"],
                 'comment': variant_row["comment_on_classification"],
@@ -55,7 +53,7 @@ def extract_clinvar_information(variant_row, ref_genomes: list) -> dict:
     return clinvar_dict
 
 
-def collect_clinvar_data_to_submit(clinvar_df, ref_genomes):
+def collect_clinvar_data_to_submit(clinvar_df, ref_genomes) -> List:
     '''
     Cycle through a dataframe, and extract variants for each row. Call the
     function to reformat this into a dictionary for submission to ClinVar and

--- a/utils/clinvar.py
+++ b/utils/clinvar.py
@@ -59,10 +59,10 @@ def collect_clinvar_data_to_submit(clinvar_df, ref_genomes):
     Cycle through a dataframe, and extract variants for each row. Call the
     function to reformat this into a dictionary for submission to ClinVar and
     return a list of these dictionaries
-    Inputs
+    Inputs:
         clinvar_df (pandas.Dataframe): variant dataframe
         ref_genomes (list): list of valid reference genome values from config
-    Outputs
+    Outputs:
         variants (list): list of dictionaries with variant data for submission
         to ClinVar
     '''
@@ -134,7 +134,7 @@ def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json):
 def process_submission_status(status, response):
     '''
     Process response to API query about submission status.
-    Inputs
+    Inputs:
         status (str): Overall submission status
         response (dict): API response, which is a breakdown the response for
         each variant or errors if submission failed.

--- a/utils/clinvar.py
+++ b/utils/clinvar.py
@@ -3,15 +3,16 @@ import requests
 import json
 from requests.adapters import HTTPAdapter, Retry
 from utils.database_actions import add_clinvar_submission_error_to_db
+from typing import List, Dict, Any, Tuple, Optional
 
-def extract_clinvar_information(variant_row, ref_genomes):
+def extract_clinvar_information(variant_row, ref_genomes: list) -> dict:
     '''
     Extract information from Shire variant record and reformat into dictionary
     Inputs:
         variant: row from variant dataframe with data for one variant
         ref_genomes (list): list of valid reference genome values from config
     outputs:
-        clinvar_dict: dictionary of data to submit to clinvar
+        clinvar_dict (dict): dictionary of data to submit to clinvar
     '''
     if variant_row["ref_genome"] not in ref_genomes:
         raise ValueError("Invalid genome build")
@@ -74,7 +75,7 @@ def collect_clinvar_data_to_submit(clinvar_df, ref_genomes):
     return variants
 
 
-def create_header(api_key):
+def create_header(api_key: str) -> Dict[str, str]:
     '''
     Format header for ClinVar API submission
     Inputs:
@@ -89,7 +90,14 @@ def create_header(api_key):
     return header
 
 
-def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json, no_retry_option=False):
+def clinvar_api_request(
+    url: str,
+    header: Dict[str, str],
+    var_list: List[Dict[str, Any]],
+    org_guidelines_url: str,
+    print_json: bool,
+    no_retry_option: bool = False
+) -> requests.Response:
     '''
     Make request to the ClinVar API endpoint specified.
     Inputs:
@@ -137,7 +145,7 @@ def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json, n
     return response
 
 
-def process_submission_status(status, response):
+def process_submission_status(status: str, response: dict) -> Tuple[dict, dict]:
     '''
     Process response to API query about submission status.
     Inputs:

--- a/utils/clinvar.py
+++ b/utils/clinvar.py
@@ -89,7 +89,7 @@ def create_header(api_key):
     return header
 
 
-def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json):
+def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json, no_retry_option=False):
     '''
     Make request to the ClinVar API endpoint specified.
     Inputs:
@@ -100,6 +100,9 @@ def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json):
         different for CUH and NUH.
         print_json (boolean): controls whether or not to print each submission
         JSON
+    no_retry_option (boolean): if True, no retries will be attempted on
+        connection errors; if False, will retry up to 10 times with a backoff
+        factor of 0.5 seconds.
     Returns:
         response: API response object
     '''
@@ -125,7 +128,10 @@ def clinvar_api_request(url, header, var_list, org_guidelines_url, print_json):
         print(json.dumps(clinvar_data, indent=4, default=str))
 
     s = requests.Session()
-    retries = Retry(total=10, backoff_factor=0.5)
+    if no_retry_option:
+        retries = Retry(total=0)
+    else:
+        retries = Retry(total=10, backoff_factor=0.5)
     s.mount('https://', HTTPAdapter(max_retries=retries))
     response = s.post(url, data=json.dumps(clinvar_data, default=str), headers=header)
     return response

--- a/utils/clinvar.py
+++ b/utils/clinvar.py
@@ -9,7 +9,7 @@ def extract_clinvar_information(variant_row, ref_genomes):
     Extract information from Shire variant record and reformat into dictionary
     Inputs:
         variant: row from variant dataframe with data for one variant
-        ref_genomes (list): list of valid reference genome values from config 
+        ref_genomes (list): list of valid reference genome values from config
     outputs:
         clinvar_dict: dictionary of data to submit to clinvar
     '''

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -32,12 +32,14 @@ def add_wb_to_db(workbook, parse_status, engine):
         None, adds data to db
     '''
     now = datetime.datetime.now()
-    engine.execute(
-        f"INSERT INTO testdirectory.inca_workbooks"
-        " (workbook_name, date, parse_status) "
-        f"VALUES ('{workbook}', '{now}', {parse_status}) "
-        "ON CONFLICT (workbook_name) DO NOTHING"
-    )
+
+    query = text("""
+        INSERT INTO testdirectory.inca_workbooks
+        (workbook_name, date, parse_status)
+        VALUES (:wb, :date, :status)
+        ON CONFLICT (workbook_name) DO NOTHING
+    """)
+    engine.execute(query, {"wb": workbook, "date": now, "status": parse_status})
 
 
 def update_db_for_parsed_wb(workbook, engine):
@@ -50,10 +52,12 @@ def update_db_for_parsed_wb(workbook, engine):
     Outputs:
         None, adds data to db
     '''
-    engine.execute(
-        "UPDATE testdirectory.inca_workbooks SET parse_status = TRUE "
-        f"WHERE workbook_name = '{workbook}'"
-    )
+    query = text("""
+        UPDATE testdirectory.inca_workbooks
+        SET parse_status = TRUE
+        WHERE workbook_name = :wb
+    """)
+    engine.execute(query, {"wb": workbook})
 
 
 def add_submission_id_to_db(response, engine, variants):
@@ -69,6 +73,7 @@ def add_submission_id_to_db(response, engine, variants):
     add_quotes = [f"'{x}'" for x in variants]
     submitted_variants = ", ".join(add_quotes)
     sub_id = response.get('id')
+
     if sub_id:
         engine.execute(
             f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
@@ -90,17 +95,18 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
         submitted (str): value for column submission_id to filter SQL SELECT
         statement on
-        exclude (str): Optional string for further filtering. 
+        exclude (str): Optional string for further filtering.
     Outputs:
         df (pandas.DataFrame): dataframe of records in table that meet the
         given filter
     '''
-    df = pd.read_sql(
-            "SELECT * FROM testdirectory.inca WHERE interpreted = 'yes' AND "
-            f"submission_id is {submitted} AND accession_id is NULL AND "
-            f"organisation_id = '{organisation_id}'{exclude}",
-            engine
-        )
+    query_str = (
+        "SELECT * FROM testdirectory.inca "
+        "WHERE interpreted = 'yes' AND submission_id is " + submitted +
+        " AND accession_id is NULL AND organisation_id = :org_id" +
+        exclude
+    )
+    df = pd.read_sql(text(query_str), engine, params={"org_id": organisation_id})
     return df
 
 
@@ -114,10 +120,9 @@ def select_workbooks_from_db(engine, parameter):
         df (pandas.DataFrame): dataframe of records in table that meet the
         given parameter
     '''
-    df = pd.read_sql(
-            f"SELECT * FROM testdirectory.inca_workbooks WHERE {parameter}",
-            engine
-        )
+    query = f"SELECT * FROM testdirectory.inca_workbooks WHERE {parameter}"
+    df = pd.read_sql(text(query), engine)
+
     return df
 
 
@@ -149,9 +154,13 @@ def add_accession_ids_to_db(accession_ids, engine):
         None, adds data to db
     '''
     for local_id, accession in accession_ids.items():
+        query = text("""
+            UPDATE testdirectory.inca
+            SET accession_id = :accession
+            WHERE local_id = :local_id
+        """)
         engine.execute(
-            f"UPDATE testdirectory.inca SET accession_id = '{accession}' "
-            f"WHERE local_id = '{local_id}'"
+            query, {"accession": accession, "local_id": local_id}
         )
 
 
@@ -166,7 +175,11 @@ def add_clinvar_submission_error_to_db(errors, engine):
         None, adds data to db
     '''
     for local_id, error in errors.items():
+        query = text("""
+            UPDATE testdirectory.inca
+            SET clinvar_status = :error
+            WHERE local_id = :local_id
+        """)
         engine.execute(
-            f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
-            f"WHERE local_id = '{local_id}'"
+            query, {"error": error, "local_id": local_id}
         )

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -12,7 +12,7 @@ def add_variants_to_db(df, engine):
     Outputs:
         None, adds data to db
     '''
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         # Ensure the DataFrame is not empty before attempting to write
         if df.empty:
             print("No variants to add to inca table.")
@@ -41,7 +41,7 @@ def add_wb_to_db(workbook, parse_status, engine):
     '''
     now = datetime.datetime.now()
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         result = conn.execute(
             text("INSERT INTO testdirectory.inca_workbooks "
                  "(workbook_name, date, parse_status) "
@@ -63,7 +63,7 @@ def update_db_for_parsed_wb(workbook, engine):
         None, adds data to db
     '''
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         result = conn.execute(
             text("UPDATE testdirectory.inca_workbooks "
                  "SET parse_status = TRUE "
@@ -86,7 +86,7 @@ def add_submission_id_to_db(response, engine, variants):
     add_quotes = [f"'{x}'" for x in variants]
     submitted_variants = ", ".join(add_quotes)
     sub_id = response.get('id')
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         # If submission ID exists, update the inca table with it
         # Otherwise, update the inca table with an error message
         if sub_id:
@@ -145,8 +145,9 @@ def select_workbooks_from_db(engine, parameter):
         given parameter
     '''
     query = f"SELECT * FROM testdirectory.inca_workbooks WHERE {parameter}"
-    df = pd.read_sql(text(query), engine)
-
+    with engine.connect() as conn:
+        # Use text to safely parameterize the query
+        df = pd.read_sql(text(query), conn)
     return df
 
 
@@ -166,7 +167,7 @@ def add_error_to_db(engine, workbook, error):
         SET parse_status = FALSE, comment = :err
         WHERE workbook_name = :wb
     """)
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         conn.execute(query, {"err": error, "wb": workbook})
 
 
@@ -180,15 +181,14 @@ def add_accession_ids_to_db(accession_ids, engine):
     Outputs:
         None, adds data to db
     '''
-    for local_id, accession in accession_ids.items():
-        query = text("""
+    query = text("""
             UPDATE testdirectory.inca
             SET accession_id = :accession
             WHERE local_id = :local_id
         """)
-        engine.execute(
-            query, {"accession": accession, "local_id": local_id}
-        )
+    payload = [{"accession": acc, "local_id": local_id} for local_id, acc in accession_ids.items()]
+    with engine.begin() as conn:
+        conn.execute(query, payload)
 
 
 def add_clinvar_submission_error_to_db(errors, engine):
@@ -202,13 +202,14 @@ def add_clinvar_submission_error_to_db(errors, engine):
     Outputs:
         None, adds data to db
     '''
-    with engine.connect() as conn:
-        # Iterate through errors and update each local_id with its error
-        for local_id, error in errors.items():
-            query = text("""
+    query = text("""
                 UPDATE testdirectory.inca
                 SET clinvar_status = :error
                 WHERE local_id = :local_id
             """)
-            conn.execute(query, {"error": error, "local_id": local_id})
+    payload = [{"error": err, "local_id": lid} for lid, err in errors.items()]
+
+    with engine.begin() as conn:
+        # Batch submission which updates each local_id with its error
+        conn.execute(query, payload)
 

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -49,6 +49,7 @@ def add_wb_to_db(workbook, parse_status, engine):
                  "ON CONFLICT (workbook_name) DO NOTHING"),
             {"wb": workbook, "date": now, "status": parse_status}
         )
+        print(f"Added {result.rowcount} records to inca_workbooks table")
 
 
 def update_db_for_parsed_wb(workbook, engine):
@@ -70,6 +71,7 @@ def update_db_for_parsed_wb(workbook, engine):
                  "WHERE workbook_name = :wb"),
             {"wb": workbook}
         )
+        print(f"Updated {result.rowcount} records in inca_workbooks table")
 
 
 def add_submission_id_to_db(response, engine, variants):

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import datetime
+from sqlalchemy import text
 
 def add_variants_to_db(df, engine):
     '''
@@ -130,10 +131,12 @@ def add_error_to_db(engine, workbook, error):
     Outputs:
         None, adds data to db
     '''
-    engine.execute(
-        "UPDATE testdirectory.inca_workbooks SET parse_status = FALSE, "
-        f"comment = '{error}' WHERE workbook_name = '{workbook}'"
-    )
+    query = text("""
+        UPDATE testdirectory.inca_workbooks
+        SET parse_status = FALSE, comment = :err
+        WHERE workbook_name = :wb
+    """)
+    engine.execute(query, {"err": error, "wb": workbook})
 
 
 def add_accession_ids_to_db(accession_ids, engine):

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -4,10 +4,10 @@ import datetime
 def add_variants_to_db(df, engine):
     '''
     Update inca table to add variants
-    Inputs
+    Inputs:
         df (pd.Dataframe): dataframe with variant information
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     rows = df.to_sql(
@@ -23,11 +23,11 @@ def add_variants_to_db(df, engine):
 def add_wb_to_db(workbook, parse_status, engine):
     '''
     Update inca_workbooks table to add workbooks
-    Inputs
+    Inputs:
         workbook (str): filename of workbook
         parse_status (str): value to use for parse_status
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     now = datetime.datetime.now()
@@ -43,10 +43,10 @@ def update_db_for_parsed_wb(workbook, engine):
     '''
     Update inca_workbooks table to set parse_status to true for parsed
     workbooks
-    Inputs
+    Inputs:
         workbook (str): filename of workbook
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     engine.execute(
@@ -58,11 +58,11 @@ def update_db_for_parsed_wb(workbook, engine):
 def add_submission_id_to_db(response, engine, variants):
     '''
     Add batch submission ID to inca table for all submitted variants
-    Inputs
+    Inputs:
         Response (dict): API response
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
         variants (list): list of variants submitted in API call
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     add_quotes = [f"'{x}'" for x in variants]
@@ -84,13 +84,13 @@ def add_submission_id_to_db(response, engine, variants):
 def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
     '''
     Select variants from inca table
-    Inputs
+    Inputs:
         organisation_id (str): ClinVar organisation ID for NUH or CUH
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
         submitted (str): value for column submission_id to filter SQL SELECT
         statement on
         exclude (str): Optional string for further filtering. 
-    Outputs
+    Outputs:
         df (pandas.DataFrame): dataframe of records in table that meet the
         given filter
     '''
@@ -106,10 +106,10 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
 def select_workbooks_from_db(engine, parameter):
     '''
     Select workbooks from inca_workbooks table
-    Inputs
+    Inputs:
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
         parameter (str): parameter to filter SQL SELECT statement on
-    Outputs
+    Outputs:
         df (pandas.DataFrame): dataframe of records in table that meet the
         given parameter
     '''
@@ -123,11 +123,11 @@ def select_workbooks_from_db(engine, parameter):
 def add_error_to_db(engine, workbook, error):
     '''
     If a workbook failed parsing, add the reason to the inca_workbooks table
-    Inputs
+    Inputs:
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
         workbook (str): file name of workbook
         error (str): reason for workbook failing parsing
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     engine.execute(
@@ -139,10 +139,10 @@ def add_error_to_db(engine, workbook, error):
 def add_accession_ids_to_db(accession_ids, engine):
     '''
     Add ClinVar accession IDs to INCA database
-    Inputs
+    Inputs:
         accession_ids (dict): dict mapping local_id to ClinVar accession ID
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     for local_id, accession in accession_ids.items():
@@ -155,11 +155,11 @@ def add_accession_ids_to_db(accession_ids, engine):
 def add_clinvar_submission_error_to_db(errors, engine):
     '''
     Add any ClinVar submission error to INCA database
-    Inputs
+    Inputs:
         errors (dict): dict mapping local_id to ClinVar submission error
         message
         engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
-    Outputs
+    Outputs:
         None, adds data to db
     '''
     for local_id, error in errors.items():

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -102,9 +102,10 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
     '''
     query_str = (
         "SELECT * FROM testdirectory.inca "
-        "WHERE interpreted = 'yes' AND submission_id is " + submitted +
-        " AND accession_id is NULL AND organisation_id = :org_id" +
-        exclude
+        "WHERE interpreted = 'yes' AND submission_id IS " + submitted +
+        " AND accession_id IS NULL AND organisation_id = :org_id"
+        " AND allele_origin = 'germline' "
+        + exclude
     )
     df = pd.read_sql(text(query_str), engine, params={"org_id": organisation_id})
     return df

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -7,18 +7,25 @@ def add_variants_to_db(df, engine):
     Update inca table to add variants
     Inputs:
         df (pd.Dataframe): dataframe with variant information
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
     Outputs:
         None, adds data to db
     '''
-    rows = df.to_sql(
-        "inca",
-        engine,
-        if_exists='append',
-        schema='testdirectory',
-        index=False
-    )
-    print(f"Added {rows} records to inca table")
+    with engine.connect() as conn:
+        # Ensure the DataFrame is not empty before attempting to write
+        if df.empty:
+            print("No variants to add to inca table.")
+            return
+        # Use the to_sql method to write the DataFrame to the database
+        rows = df.to_sql(
+            "inca",
+            conn,
+            if_exists='append',
+            schema='testdirectory',
+            index=False
+        )
+        print(f"Added {rows} records to inca table")
 
 
 def add_wb_to_db(workbook, parse_status, engine):
@@ -27,7 +34,8 @@ def add_wb_to_db(workbook, parse_status, engine):
     Inputs:
         workbook (str): filename of workbook
         parse_status (str): value to use for parse_status
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
     Outputs:
         None, adds data to db
     '''
@@ -49,7 +57,8 @@ def update_db_for_parsed_wb(workbook, engine):
     workbooks
     Inputs:
         workbook (str): filename of workbook
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
     Outputs:
         None, adds data to db
     '''
@@ -68,7 +77,8 @@ def add_submission_id_to_db(response, engine, variants):
     Add batch submission ID to inca table for all submitted variants
     Inputs:
         Response (dict): API response
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
         variants (list): list of variants submitted in API call
     Outputs:
         None, adds data to db
@@ -76,18 +86,20 @@ def add_submission_id_to_db(response, engine, variants):
     add_quotes = [f"'{x}'" for x in variants]
     submitted_variants = ", ".join(add_quotes)
     sub_id = response.get('id')
-
-    if sub_id:
-        engine.execute(
-            f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
-            f"WHERE local_id in ({submitted_variants})"
-        )
-    else:
-        error = response.get('message')
-        engine.execute(
-            f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
-            f"WHERE local_id in ({submitted_variants})"
-        )
+    with engine.connect() as conn:
+        # If submission ID exists, update the inca table with it
+        # Otherwise, update the inca table with an error message
+        if sub_id:
+            conn.execute(
+                f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
+                f"WHERE local_id in ({submitted_variants})"
+            )
+        else:
+            error = response.get('message')
+            conn.execute(
+                f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
+                f"WHERE local_id in ({submitted_variants})"
+            )
 
 
 def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
@@ -95,7 +107,8 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
     Select variants from inca table
     Inputs:
         organisation_id (str): ClinVar organisation ID for NUH or CUH
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
         submitted (str): value for column submission_id to filter SQL SELECT
         statement on
         exclude (str): Optional string for further filtering.
@@ -114,7 +127,9 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
         " AND allele_origin = 'germline' "
         + exclude
     )
-    df = pd.read_sql(text(query_str), engine, params={"org_id": organisation_id})
+    with engine.connect() as conn:
+        # Use text to safely parameterize the query
+        df = pd.read_sql(text(query_str), conn, params={"org_id": organisation_id})
     return df
 
 
@@ -122,7 +137,8 @@ def select_workbooks_from_db(engine, parameter):
     '''
     Select workbooks from inca_workbooks table
     Inputs:
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
         parameter (str): parameter to filter SQL SELECT statement on
     Outputs:
         df (pandas.DataFrame): dataframe of records in table that meet the
@@ -138,7 +154,8 @@ def add_error_to_db(engine, workbook, error):
     '''
     If a workbook failed parsing, add the reason to the inca_workbooks table
     Inputs:
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
         workbook (str): file name of workbook
         error (str): reason for workbook failing parsing
     Outputs:
@@ -158,7 +175,8 @@ def add_accession_ids_to_db(accession_ids, engine):
     Add ClinVar accession IDs to INCA database
     Inputs:
         accession_ids (dict): dict mapping local_id to ClinVar accession ID
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
     Outputs:
         None, adds data to db
     '''
@@ -179,7 +197,8 @@ def add_clinvar_submission_error_to_db(errors, engine):
     Inputs:
         errors (dict): dict mapping local_id to ClinVar submission error
         message
-        engine (sqlalchemy.engine.Engine): SQLAlchemy connection to AWS db
+        engine (sqlalchemy.engine.Engine):
+            SQLAlchemy engine for connection to AWS db
     Outputs:
         None, adds data to db
     '''

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -116,7 +116,7 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
         df (pandas.DataFrame): dataframe of records in table that meet the
         given filter
     '''
-    # santise organisation_id to ensure it is a string
+    # sanitise organisation_id to ensure it is a string
     if not isinstance(organisation_id, str):
         organisation_id = str(organisation_id)
 

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -33,13 +33,14 @@ def add_wb_to_db(workbook, parse_status, engine):
     '''
     now = datetime.datetime.now()
 
-    query = text("""
-        INSERT INTO testdirectory.inca_workbooks
-        (workbook_name, date, parse_status)
-        VALUES (:wb, :date, :status)
-        ON CONFLICT (workbook_name) DO NOTHING
-    """)
-    engine.execute(query, {"wb": workbook, "date": now, "status": parse_status})
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("INSERT INTO testdirectory.inca_workbooks "
+                 "(workbook_name, date, parse_status) "
+                 "VALUES (:wb, :date, :status) "
+                 "ON CONFLICT (workbook_name) DO NOTHING"),
+            {"wb": workbook, "date": now, "status": parse_status}
+        )
 
 
 def update_db_for_parsed_wb(workbook, engine):
@@ -52,12 +53,14 @@ def update_db_for_parsed_wb(workbook, engine):
     Outputs:
         None, adds data to db
     '''
-    query = text("""
-        UPDATE testdirectory.inca_workbooks
-        SET parse_status = TRUE
-        WHERE workbook_name = :wb
-    """)
-    engine.execute(query, {"wb": workbook})
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("UPDATE testdirectory.inca_workbooks "
+                 "SET parse_status = TRUE "
+                 "WHERE workbook_name = :wb"),
+            {"wb": workbook}
+        )
 
 
 def add_submission_id_to_db(response, engine, variants):
@@ -100,6 +103,10 @@ def select_variants_from_db(organisation_id, engine, submitted, exclude=""):
         df (pandas.DataFrame): dataframe of records in table that meet the
         given filter
     '''
+    # santise organisation_id to ensure it is a string
+    if not isinstance(organisation_id, str):
+        organisation_id = str(organisation_id)
+
     query_str = (
         "SELECT * FROM testdirectory.inca "
         "WHERE interpreted = 'yes' AND submission_id IS " + submitted +
@@ -142,7 +149,8 @@ def add_error_to_db(engine, workbook, error):
         SET parse_status = FALSE, comment = :err
         WHERE workbook_name = :wb
     """)
-    engine.execute(query, {"err": error, "wb": workbook})
+    with engine.connect() as conn:
+        conn.execute(query, {"err": error, "wb": workbook})
 
 
 def add_accession_ids_to_db(accession_ids, engine):
@@ -175,12 +183,13 @@ def add_clinvar_submission_error_to_db(errors, engine):
     Outputs:
         None, adds data to db
     '''
-    for local_id, error in errors.items():
-        query = text("""
-            UPDATE testdirectory.inca
-            SET clinvar_status = :error
-            WHERE local_id = :local_id
-        """)
-        engine.execute(
-            query, {"error": error, "local_id": local_id}
-        )
+    with engine.connect() as conn:
+        # Iterate through errors and update each local_id with its error
+        for local_id, error in errors.items():
+            query = text("""
+                UPDATE testdirectory.inca
+                SET clinvar_status = :error
+                WHERE local_id = :local_id
+            """)
+            conn.execute(query, {"error": error, "local_id": local_id})
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -47,6 +47,13 @@ def get_workbook_data(workbook, config, filename, file, engine, organisation):
     df_interpret, error = get_report_fields(workbook, config, df_included)
     errors.append(error)
 
+    # Check if df_summary is None due to error in get_summary_fields
+    if df_summary is None:
+        errors_to_add = [err for err in errors if err is not None]
+        error_to_add = ", ".join(errors_to_add)
+        add_error_to_db(engine, file, error_to_add)
+        return None
+
     # merge these to get one df
     if not df_included.empty and not df_summary.empty:
         df_merged = pd.merge(df_included, df_summary, how="cross")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -161,7 +161,7 @@ def get_summary_fields(
     # compatible
     # Can test with first item in series as all rows have the same date value
     try:
-        r = bool(date_parser.parse(str(df_summary['date_last_evaluated'][0])))
+        _ = bool(date_parser.parse(str(df_summary['date_last_evaluated'][0])))
     except date_parser._parser.ParserError:
         error_msg = (
             f"Value for date last evaluated \"{date_evaluated}\" is not "

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -9,6 +9,7 @@ import requests
 import json
 import uuid
 import time
+from typing import Optional
 
 
 def get_folder_of_input_file(filename: str) -> str:
@@ -23,7 +24,14 @@ def get_folder_of_input_file(filename: str) -> str:
     return folder
 
 
-def get_workbook_data(workbook, config, filename, file, engine, organisation):
+def get_workbook_data(
+    workbook,
+    config: dict,
+    filename: str,
+    file: str,
+    engine,
+    organisation: str
+    ) -> pd.DataFrame:
     '''
     Function that runs functions to extract data from each sheet in the
     workbook and merges it together into one dataframe
@@ -84,7 +92,9 @@ def get_workbook_data(workbook, config, filename, file, engine, organisation):
     return df_final
 
 
-def get_summary_fields(workbook, config, organisation):
+def get_summary_fields(
+    workbook, config: dict, organisation
+    ) -> tuple[pd.DataFrame, str]:
     '''
     Extract data from summary sheet of variant workbook
     Inputs:
@@ -185,7 +195,7 @@ def get_summary_fields(workbook, config, organisation):
     return df_summary, error_msg
 
 
-def get_included_fields(workbook, filename) -> pd.DataFrame:
+def get_included_fields(workbook, filename: str) -> pd.DataFrame:
     '''
     Extract data from included sheet of variant workbook
     Inputs:
@@ -239,7 +249,11 @@ def get_included_fields(workbook, filename) -> pd.DataFrame:
     return df
 
 
-def get_report_fields(workbook, config, df_included):
+def get_report_fields(
+    workbook,
+    config: dict,
+    df_included: pd.DataFrame
+    ) -> tuple[pd.DataFrame, str]:
     '''
     Extract data from interpret sheet(s) of variant workbook
     Inputs:
@@ -280,7 +294,7 @@ def get_report_fields(workbook, config, df_included):
     return df_report, error_msg
 
 
-def make_acgs_criteria_null_if_not_applied(df, acgs_criteria):
+def make_acgs_criteria_null_if_not_applied(df, acgs_criteria: list) -> pd.DataFrame:
     '''
     The workbook has a value "NA" for ACGS criteria that was not applied. This
     function finds any variant row that had "NA" for a criteria and changes it
@@ -310,7 +324,7 @@ def make_acgs_criteria_null_if_not_applied(df, acgs_criteria):
     return df
 
 
-def add_comment_on_classification(df, acgs_criteria, config):
+def add_comment_on_classification(df, acgs_criteria: list, config: dict) -> pd.DataFrame:
     '''
     This function should take in a df with a column for each ACGS criteria with
     the values in that column being the strength of the criteria and return the
@@ -355,7 +369,7 @@ def add_comment_on_classification(df, acgs_criteria, config):
     return df
 
 
-def select_api_url(clinvar_testing, config):
+def select_api_url(clinvar_testing: bool, config: dict) -> Optional[str]:
     '''
     Select which API URL to use depending on if this is a test run or if
     variants are planned to be submitted to ClinVar
@@ -383,7 +397,10 @@ def select_api_url(clinvar_testing, config):
     return api_url
 
 
-def check_interpret_table(df_interpret, df_included, config):
+def check_interpret_table(
+    df_interpret: pd.DataFrame,
+    df_included: pd.DataFrame,
+    config: dict) -> Optional[str]:
     '''
     Check if ACMG classification and HGVSc are correctly
     filled in in the interpret table(s)
@@ -394,7 +411,7 @@ def check_interpret_table(df_interpret, df_included, config):
     Outputs:
       error_msg (str): error message
     '''
-    error_msg = []
+    error_msg_list = []
     strength_dropdown = config.get("strength_dropdown")
     BA1_dropdown = config.get("BA1_dropdown")
     for row in range(df_interpret.shape[0]):
@@ -429,9 +446,9 @@ def check_interpret_table(df_interpret, df_included, config):
                 ), "Wrong strength in BA1"
 
         except AssertionError as msg:
-            error_msg.append(str(msg))
+            error_msg_list.append(str(msg))
 
-    error_msg = "".join(error_msg)
+    error_msg = "".join(error_msg_list)
 
     if error_msg == "":
         error_msg = None
@@ -439,7 +456,7 @@ def check_interpret_table(df_interpret, df_included, config):
     return error_msg
 
 
-def checking_sheets(workbook):
+def checking_sheets(workbook) -> Optional[str]:
     '''
     Check if extra row(s)/col(s) are added in the sheets
     Inputs:
@@ -474,37 +491,37 @@ def checking_sheets(workbook):
     return error_msg
 
 
-def check_interpreted_col(df):
+def check_interpreted_col(df) -> Optional[str]:
     '''
     Check if interpreted col in included sheet is correctly filled in
     Inputs:
         df (pd.DataFrame): merged dataframe with data from workbook
         error_msg (str): error message
     '''
-    error_msg = []
+    error_msg_list = []
     yes_df = df[df["interpreted"] == "yes"]
     no_df = df[df["interpreted"] == "no"]
 
     if not df["interpreted"].isin(['yes', 'no']).all():
-        error_msg.append(
+        error_msg_list.append(
             "Values in interpreted column are not all either 'yes' or 'no'"
         )
 
     for index, row in yes_df.iterrows():
         if pd.isna(row["germline_classification"]):
-            error_msg.append(
+            error_msg_list.append(
                 f"Variant {row['hgvsc']} has interpreted = yes, but no final "
                 "classification could be extracted from interpret sheets."
             )
 
     for index, row in no_df.iterrows():
         if pd.notna(row["germline_classification"]):
-            error_msg.append(
+            error_msg_list.append(
                 f"Variant {row['hgvsc']} has interpreted = no, but a final "
                 "classification could be extracted from interpret sheets."
             )
 
-    error_msg = " ".join(error_msg)
+    error_msg = " ".join(error_msg_list)
 
     if error_msg == "":
         error_msg = None
@@ -512,7 +529,13 @@ def check_interpreted_col(df):
     return error_msg
 
 
-def check_sample_name(instrumentID, sample_ID, batchID, testcode, probesetID):
+def check_sample_name(
+    instrumentID: str,
+    sample_ID: str,
+    batchID: str,
+    testcode: str,
+    probesetID: str
+    ) -> Optional[str]:
     '''
     Checking that individual parts of sample name have expected naming format
     Inputs:
@@ -539,16 +562,21 @@ def check_sample_name(instrumentID, sample_ID, batchID, testcode, probesetID):
     return error_msg
 
 
-def submission_status_check(submission_id, headers, api_url):
+def submission_status_check(
+    submission_id: str,
+    headers: dict,
+    api_url: str
+    ) -> tuple[str, dict]:
     '''
     Queries ClinVar API about a submission ID to obtain more details about its
     submission record.
     Inputs:
-        submission_id:  the generated submission id from ClinVar when a
+        submission_id (str):  the generated submission id from ClinVar when a
         submission has been posted to their API
-        headers: the required API url
+        headers (dict): the required API url
     Outputs:
-        status_response: the API response
+        status (str): the submission status
+        status_response (dict): the API response
     '''
 
     url = os.path.join(api_url, submission_id, "actions")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -26,13 +26,13 @@ def get_workbook_data(workbook, config, filename, file, engine):
     '''
     Function that runs functions to extract data from each sheet in the
     workbook and merges it together into one dataframe
-    Inputs
+    Inputs:
         workbook (openpyxl wb object): workbook being used
         config (dict): config variable
         filename (str): string of workbook name with preceding path
         file (str): string of workbook name without preceding path
         engine (SQLAlchemy engine): connection to database
-    Outputs
+    Outputs:
         df_final (pd.DataFrame): data frame extracted from workbook
     '''
     errors = []
@@ -76,11 +76,11 @@ def get_workbook_data(workbook, config, filename, file, engine):
 def get_summary_fields(workbook, config, filename):
     '''
     Extract data from summary sheet of variant workbook
-    Inputs
+    Inputs:
         workbook (openpyxl wb object): workbook being used
         config (dict): config variable
         filename (str): string of workbook name
-    Outputs
+    Outputs:
         df_summary (pd.DataFrame): data frame extracted from workbook summary
         sheet
         err_msg (str): error message
@@ -179,7 +179,7 @@ def get_included_fields(workbook, filename) -> pd.DataFrame:
     Inputs:
         workbook (openpyxl wb object): workbook being used
         filename (str): string of workbook name
-    Outputs
+    Outputs:
         df_included (pd.DataFrame): data frame extracted from included sheet
     '''
     num_variants = workbook["summary"]["C38"].value
@@ -234,7 +234,7 @@ def get_report_fields(workbook, config, df_included):
         workbook (openpyxl wb object): workbook being used
         config (dict): config variable
         df_included (pd.DataFrame): data frame extracted from included sheet
-    Outputs
+    Outputs:
         df_included (pd.DataFrame): dataframe extracted from interpret sheet(s)
         err_msg (str): error message
 
@@ -346,10 +346,10 @@ def select_api_url(clinvar_testing, config):
     '''
     Select which API URL to use depending on if this is a test run or if
     variants are planned to be submitted to ClinVar
-    Inputs
+    Inputs:
         clinvar_testing (bool): if True, use test API. If false, use live API
         config (dict): config variable containing URLS for API
-    Outputs
+    Outputs:
         api_url: clinvar api URL, either for the test API or the live API
     '''
     if clinvar_testing is True:
@@ -374,11 +374,11 @@ def check_interpret_table(df_interpret, df_included, config):
     '''
     Check if ACMG classification and HGVSc are correctly
     filled in in the interpret table(s)
-    Inputs
+    Inputs:
         df_interpret (pd.Dataframe): df from interpret sheet(s)
         df_included (pd.Dataframe): df from included sheet
         config (dict): config variable
-    Outputs
+    Outputs:
       error_msg (str): error message
     '''
     error_msg = []
@@ -429,9 +429,9 @@ def check_interpret_table(df_interpret, df_included, config):
 def checking_sheets(workbook):
     '''
     Check if extra row(s)/col(s) are added in the sheets
-    Inputs
+    Inputs:
         workbook (openpyxl wb object): object of query workbook with variants
-    Outputs
+    Outputs:
         error_msg (str): error message
     '''
     summary = workbook["summary"]
@@ -464,7 +464,7 @@ def checking_sheets(workbook):
 def check_interpreted_col(df):
     '''
     Check if interpreted col in included sheet is correctly filled in
-    Inputs
+    Inputs:
         df (pd.DataFrame): merged dataframe with data from workbook
         error_msg (str): error message
     '''
@@ -502,10 +502,10 @@ def check_interpreted_col(df):
 def check_sample_name(instrumentID, sample_ID, batchID, testcode, probesetID):
     '''
     Checking that individual parts of sample name have expected naming format
-    Inputs
+    Inputs:
       str values for instrumentID, sample_ID, batchID, testcode,
       probesetID
-    Outputs
+    Outputs:
         error_msg (str): error message
     '''
     try:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -262,7 +262,7 @@ def get_report_fields(
 
     '''
     field_cells = config.get("field_cells")
-    print(field_cells)
+
     col_name = [i[0] for i in field_cells]
     df_report = pd.DataFrame(columns=col_name)
     report_sheets = [

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -14,7 +14,7 @@ def get_folder_of_input_file(filename: str) -> str:
     '''
     Get the folder of input file
     Inputs:
-        filename (str): filename 
+        filename (str): filename
     Outputs:
         folder (str): folder name
     '''

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -4,6 +4,7 @@ from utils.database_actions import add_error_to_db
 import pandas as pd
 import numpy as np
 import os
+import re
 import requests
 import json
 import uuid
@@ -161,6 +162,10 @@ def get_summary_fields(workbook, config, organisation):
     df_summary["affected_status"] = config.get("Affected status")
 
     # Set organisation and organisation_id based on laboratory
+    organisation = organisation.upper()
+    if organisation not in ["CUH", "NUH"]:
+        error_msg = "Organisation must be CUH or NUH"
+        return df_summary, error_msg
     if organisation == "CUH":
         df_summary["organisation"] = config.get("CUH Organisation")
         df_summary["organisation_id"] = config.get("CUH org ID")
@@ -168,7 +173,6 @@ def get_summary_fields(workbook, config, organisation):
     elif organisation == "NUH":
         df_summary["organisation"] = config.get("NUH Organisation")
         df_summary["organisation_id"] = config.get("NUH org ID")
-
     else:
         error_msg = "Workbook folder is not CUH or NUH folder given in config"
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -22,7 +22,7 @@ def get_folder_of_input_file(filename: str) -> str:
     return folder
 
 
-def get_workbook_data(workbook, config, filename, file, engine):
+def get_workbook_data(workbook, config, filename, file, engine, organisation):
     '''
     Function that runs functions to extract data from each sheet in the
     workbook and merges it together into one dataframe
@@ -32,12 +32,16 @@ def get_workbook_data(workbook, config, filename, file, engine):
         filename (str): string of workbook name with preceding path
         file (str): string of workbook name without preceding path
         engine (SQLAlchemy engine): connection to database
+        organisation (str): string of organisation name, either CUH or NUH
     Outputs:
         df_final (pd.DataFrame): data frame extracted from workbook
     '''
     errors = []
     # get data from summary sheet, included variants sheet and interpret sheets
-    df_summary, error = get_summary_fields(workbook, config, filename)
+    df_summary, error = get_summary_fields(
+        workbook, config,
+        filename, organisation
+        )
     errors.append(error)
     df_included = get_included_fields(workbook, filename)
     df_interpret, error = get_report_fields(workbook, config, df_included)
@@ -73,13 +77,13 @@ def get_workbook_data(workbook, config, filename, file, engine):
     return df_final
 
 
-def get_summary_fields(workbook, config, filename):
+def get_summary_fields(workbook, config, organisation):
     '''
     Extract data from summary sheet of variant workbook
     Inputs:
         workbook (openpyxl wb object): workbook being used
         config (dict): config variable
-        filename (str): string of workbook name
+        organisation (str): string of organisation name, either CUH or NUH
     Outputs:
         df_summary (pd.DataFrame): data frame extracted from workbook summary
         sheet
@@ -156,14 +160,12 @@ def get_summary_fields(workbook, config, filename):
     df_summary["allele_origin"] = config.get("Allele origin")
     df_summary["affected_status"] = config.get("Affected status")
 
-    # getting the folder name of workbook
-    # the folder name should return designated folder for either CUH or NUH
-    folder_name = get_folder_of_input_file(filename)
-    if folder_name == config.get("CUH folder"):
+    # Set organisation and organisation_id based on laboratory
+    if organisation == "CUH":
         df_summary["organisation"] = config.get("CUH Organisation")
         df_summary["organisation_id"] = config.get("CUH org ID")
 
-    elif folder_name == config.get("NUH folder"):
+    elif organisation == "NUH":
         df_summary["organisation"] = config.get("NUH Organisation")
         df_summary["organisation_id"] = config.get("NUH org ID")
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -40,8 +40,7 @@ def get_workbook_data(workbook, config, filename, file, engine, organisation):
     errors = []
     # get data from summary sheet, included variants sheet and interpret sheets
     df_summary, error = get_summary_fields(
-        workbook, config,
-        filename, organisation
+        workbook, config, organisation
         )
     errors.append(error)
     df_included = get_included_fields(workbook, filename)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -178,10 +178,6 @@ def get_summary_fields(
     df_summary["affected_status"] = config.get("Affected status")
 
     # Set organisation and organisation_id based on laboratory
-    organisation = organisation.upper()
-    if organisation not in ["CUH", "NUH"]:
-        error_msg = "Organisation must be CUH or NUH"
-        return df_summary, error_msg
     if organisation == "CUH":
         df_summary["organisation"] = config.get("CUH Organisation")
         df_summary["organisation_id"] = config.get("CUH org ID")

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -48,7 +48,7 @@ def get_workbook_data(workbook, config, filename, file, engine, organisation):
     errors.append(error)
 
     # merge these to get one df
-    if not df_included.empty:
+    if not df_included.empty and not df_summary.empty:
         df_merged = pd.merge(df_included, df_summary, how="cross")
     else:
         df_merged = pd.concat([df_summary, df_included], axis=1)
@@ -245,6 +245,7 @@ def get_report_fields(workbook, config, df_included):
 
     '''
     field_cells = config.get("field_cells")
+    print(field_cells)
     col_name = [i[0] for i in field_cells]
     df_report = pd.DataFrame(columns=col_name)
     report_sheets = [

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -93,7 +93,7 @@ def get_workbook_data(
 
 
 def get_summary_fields(
-    workbook, config: dict, organisation
+    workbook, config: dict, organisation: str
     ) -> tuple[pd.DataFrame, str]:
     '''
     Extract data from summary sheet of variant workbook


### PR DESCRIPTION
**Changes to Main Script Functionality:**

* Added support for mutually exclusive arguments `--path_to_workbooks` and `--samples_file`, enabling users to specify either a directory of Excel workbooks or a CSV file with sample information. 
* Also introduced new flags for organisation (to set CUG/NUH), dry-run mode, and error handling.
* Added option for no retry: https://github.com/eastgenomics/clinvar_submissions/issues/20.
* Added potential fix for https://github.com/eastgenomics/clinvar_submissions/issues/19.
* Parameterized queries should fix: https://github.com/eastgenomics/clinvar_submissions/issues/14.
* Refactored the main workflow in `pandora.py` to handle both sources of input, skip CNV workbooks, and support dry-run mode for safe testing. Improved error handling and ensured correct SQL parameter usage with SQLAlchemy. [[1]](diffhunk://#diff-a55c08c9c0fed92be25bec257bcff8243eebf4ca0eceef398482288e17bf7e74R123-R131) [[2]](diffhunk://#diff-a55c08c9c0fed92be25bec257bcff8243eebf4ca0eceef398482288e17bf7e74L132-R170) [[3]](diffhunk://#diff-a55c08c9c0fed92be25bec257bcff8243eebf4ca0eceef398482288e17bf7e74L162-R279) [[4]](diffhunk://#diff-a55c08c9c0fed92be25bec257bcff8243eebf4ca0eceef398482288e17bf7e74L200-R301)
* Updated documentation in `README.md` to reflect new command-line options and provide example usage for both input modes.

**Docker and Environment Updates:**
* Upgraded the base image in `Dockerfile` from Python 3.8 to Python 3.12, switched to using `uv` for dependency management, and improved cache cleanup and command aliasing. The working directory was also changed to `/app` for consistency.
* Expanded `.dockerignore` to exclude additional file types and directories such as lock files, logs, temporary files, and data folders, reducing unnecessary files in the build context.

**Testing and Database Refactor**
- Refactored tests to use SQLAlchemy connections, parameterized queries, and improved assertions for correctness and reliability. [[1]](diffhunk://#diff-4eadef42cb4a60ac895edaed42ad9f30b1225ad769940768789d5ba6f4f01410R3-R70) [[2]](diffhunk://#diff-4eadef42cb4a60ac895edaed42ad9f30b1225ad769940768789d5ba6f4f01410L53-R80) [[3]](diffhunk://#diff-4eadef42cb4a60ac895edaed42ad9f30b1225ad769940768789d5ba6f4f01410R89-R180)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/21)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CLI: add --samples_file, --organisation, --dry-run and a no-retry option; mutual exclusivity with existing workbook path; dry-run previews and organisation-aware processing.

- Documentation
  - README updated with new CLI options, examples and dry-run guidance.

- Chores
  - Base runtime bumped to Python 3.12; dependency versions updated; expanded .gitignore and .dockerignore exclusions.

- Refactor
  - Safer transactional DB operations and strengthened workbook-processing flow with clearer typing.

- Tests
  - Expanded and hardened tests for utilities, DB interactions and workbook parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->