### PR TITLE
v1.1.0 Fix multiple R codes in Clarity extract

### DIFF
--- a/pandora.py
+++ b/pandora.py
@@ -126,13 +126,14 @@ def validate_output_dir(path_str: str) -> Path:
 
 
 def output_inconsistent_files(
-    missing_data_df=None, duplicate_data_df=None, timestamp=None, output_dir=None
+    missing_data_df, duplicate_data_df, clarity_issues_df, timestamp=None, output_dir=None
 ):
     """
     Output any inconsistent files from clarity extract handling for review
     Inputs:
         missing_data_df (pd.DataFrame): dataframe of samples with missing data
         duplicate_data_df (pd.DataFrame): dataframe of samples with duplicate data
+        clarity_issues_df (pd.DataFrame): dataframe of samples with clarity issues
         timestamp (str): timestamp to append to filenames
         output_dir (str): directory to output inconsistent files to
     Outputs:
@@ -140,10 +141,6 @@ def output_inconsistent_files(
     Side effects:
         Outputs CSV files if any inconsistent data found
     """
-    if missing_data_df is None:
-        missing_data_df = pd.DataFrame()
-    if duplicate_data_df is None:
-        duplicate_data_df = pd.DataFrame()
     if timestamp is None:
         print("Timestamp not provided. Not outputting inconsistent files.")
         return
@@ -167,7 +164,16 @@ def output_inconsistent_files(
             output_dir, f"duplicate_data_clarity_extract_{timestamp}.csv"
         )
         duplicate_data_df.to_csv(path_to_duplicate, index=False)
-    if missing_data_df.empty and duplicate_data_df.empty:
+    if not clarity_issues_df.empty:
+        print(
+            f"{clarity_issues_df.shape[0]} samples with clarity issues found in "
+            f"clarity extract. See clarity_issues_clarity_extract_{timestamp}.csv for details."
+        )
+        path_to_clarity_issues = os.path.join(
+            output_dir, f"clarity_issues_clarity_extract_{timestamp}.csv"
+        )
+        clarity_issues_df.to_csv(path_to_clarity_issues, index=False)
+    if missing_data_df.empty and duplicate_data_df.empty and clarity_issues_df.empty:
         print("No inconsistent data found.")
 
 
@@ -287,7 +293,7 @@ def main():
             raise SystemExit(1)
         clarity_df = pd.DataFrame()
         missing_data_df = pd.DataFrame()
-        clarity_df, missing_data_df, duplicate_data_df = (
+        clarity_df, missing_data_df, duplicate_data_df, clarity_issues_df = (
             clarity_handler.handle_clarity_extract(
                 args.clarity_extract, rd_assays, base_path
             )
@@ -313,7 +319,7 @@ def main():
                 print(f"Found {len(workbooks_to_process)} workbooks")
                 # Output any inconsistent files for review
                 output_inconsistent_files(
-                    missing_data_df, duplicate_data_df, timestamp, args.output_dir
+                    missing_data_df, duplicate_data_df, clarity_issues_df, timestamp, args.output_dir
                 )
             else:
                 print(
@@ -332,7 +338,7 @@ def main():
                     f"Clarity extract parsed paths output to {path_to_parsed_clarity}"
                 )
                 output_inconsistent_files(
-                    missing_data_df, duplicate_data_df, timestamp, args.output_dir
+                    missing_data_df, duplicate_data_df, clarity_issues_df, timestamp, args.output_dir
                 )
 
     # Get previously parsed workbooks

--- a/pandora.py
+++ b/pandora.py
@@ -292,42 +292,48 @@ def main():
                 args.clarity_extract, rd_assays, base_path
             )
         )
-        if args.use_paths:
-            print("Using paths from clarity extract directly.")
-            # Check files exist and exclude any that don't
-            clarity_df, missing_file_paths_df = utils.check_files_exist_and_exclude(
-                clarity_df, "path"
-            )
-            # merge missing data dfs
-            missing_data_df = pd.concat(
-                [missing_data_df, missing_file_paths_df], ignore_index=True
-            )
-            # remove any CNV workbooks and mosaic workbooks
-            workbooks_to_process = clarity_df["path"].tolist()
-            print(f"Found {len(workbooks_to_process)} workbooks")
-            # Output any inconsistent files for review
-            output_inconsistent_files(
-                missing_data_df, duplicate_data_df, timestamp, args.output_dir
+        if clarity_df.empty:
+            print(
+                "Clarity extract is empty after preprocessing. Skipping "
+                "processing."
             )
         else:
-            print(
-                "--use_paths not specified so outputting clarity extract dataframes for review."
-            )
-            print("These can be processed by using --samples_file option.")
-            # Output dataframes for review name after date and input clarity?
-            path_to_parsed_clarity = os.path.join(
-                args.output_dir, f"clarity_extract_parsed_paths_{timestamp}.csv"
-            )
-            clarity_df.to_csv(
-                path_to_parsed_clarity,
-                index=False,
-            )
-            print(
-                f"Clarity extract parsed paths output to {path_to_parsed_clarity}"
-            )
-            output_inconsistent_files(
-                missing_data_df, duplicate_data_df, timestamp, args.output_dir
-            )
+            if args.use_paths:
+                print("Using paths from clarity extract directly.")
+                # Check files exist and exclude any that don't
+                clarity_df, missing_file_paths_df = utils.check_files_exist_and_exclude(
+                    clarity_df, "path"
+                )
+                # merge missing data dfs
+                missing_data_df = pd.concat(
+                    [missing_data_df, missing_file_paths_df], ignore_index=True
+                )
+                # remove any CNV workbooks and mosaic workbooks
+                workbooks_to_process = clarity_df["path"].tolist()
+                print(f"Found {len(workbooks_to_process)} workbooks")
+                # Output any inconsistent files for review
+                output_inconsistent_files(
+                    missing_data_df, duplicate_data_df, timestamp, args.output_dir
+                )
+            else:
+                print(
+                    "--use_paths not specified so outputting clarity extract dataframes for review."
+                )
+                print("These can be processed by using --samples_file option.")
+                # Output dataframes for review name after date and input clarity?
+                path_to_parsed_clarity = os.path.join(
+                    args.output_dir, f"clarity_extract_parsed_paths_{timestamp}.csv"
+                )
+                clarity_df.to_csv(
+                    path_to_parsed_clarity,
+                    index=False,
+                )
+                print(
+                    f"Clarity extract parsed paths output to {path_to_parsed_clarity}"
+                )
+                output_inconsistent_files(
+                    missing_data_df, duplicate_data_df, timestamp, args.output_dir
+                )
 
     # Get previously parsed workbooks
     parsed_workbook_df = db.select_workbooks_from_db(engine, "parse_status = TRUE")

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -278,7 +278,6 @@ class TestPreProcessClarityExtract:
 
         processed_df = ceh.preprocess_clarity_extract(example_df)
 
-        # Check that paths are correctly created
         expected_df = pd.DataFrame(
             {
                 "Beaker Procedure Name": ["RARE DISEASE NGS ANALYSIS"],
@@ -308,7 +307,6 @@ class TestPreProcessClarityExtract:
 
         processed_df = ceh.preprocess_clarity_extract(example_df)
 
-        # Check that paths are correctly created
         expected_df = pd.DataFrame(
             {
                 "Beaker Procedure Name": ["CEN NGS"] * 2,
@@ -338,7 +336,6 @@ class TestPreProcessClarityExtract:
 
         processed_df = ceh.preprocess_clarity_extract(example_df)
 
-        # Check that paths are correctly created
         expected_df = pd.DataFrame(
             {
                 "Beaker Procedure Name": pd.Series([], dtype="object"),

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -276,7 +276,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -296,6 +296,18 @@ class TestPreProcessClarityExtract:
 
         pd.testing.assert_frame_equal(processed_df, expected_df)
 
+        expected_issues_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": pd.Series([], dtype="object"),
+                "Specimen Identifier": pd.Series([], dtype="object"),
+                "Test Directory Test Code": pd.Series([], dtype="object"),
+                "sample_id": pd.Series([], dtype="object"),
+                "R_codes": pd.Series([], dtype="object"),
+            }
+        )
+
+        pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
+
     def test_preprocess_clarity_df_single_R_code(self):
         example_df = pd.DataFrame(
             {
@@ -305,7 +317,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -325,6 +337,18 @@ class TestPreProcessClarityExtract:
 
         pd.testing.assert_frame_equal(processed_df, expected_df)
 
+        expected_issues_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": pd.Series([], dtype="object"),
+                "Specimen Identifier": pd.Series([], dtype="object"),
+                "Test Directory Test Code": pd.Series([], dtype="object"),
+                "sample_id": pd.Series([], dtype="object"),
+                "R_codes": pd.Series([], dtype="object"),
+            }
+        )
+
+        pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
+
     def test_preprocess_clarity_df_no_R_code(self):
         example_df = pd.DataFrame(
             {
@@ -334,7 +358,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -347,6 +371,52 @@ class TestPreProcessClarityExtract:
         )
 
         pd.testing.assert_frame_equal(processed_df, expected_df)
+
+        expected_issues_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["WES NGS"] * 2,
+                "Specimen Identifier": ["SP-250128R0042", "SP-250129R0043"],
+                "Test Directory Test Code": [pd.NA, pd.NA],
+                "sample_id": ["250128R0042", "250129R0043"],
+                "R_codes": [[], []],
+            }
+        )
+        pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
+
+    def test_preprocess_clarity_df_multiple_R_codes_and_no_R_code(self):
+        example_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["WES NGS"] * 2,
+                "Specimen Identifier": ["SP-250128R0042", "SP-250129R0043"],
+                "Test Directory Test Code": ["R208.1|R209.1", pd.NA],
+            }
+        )
+
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
+
+        expected_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": pd.Series([], dtype="object"),
+                "Specimen Identifier": pd.Series([], dtype="object"),
+                "Test Directory Test Code": pd.Series([], dtype="object"),
+                "sample_id": pd.Series([], dtype="object"),
+                "R_codes": pd.Series([], dtype="object"),
+            }
+        )
+
+        pd.testing.assert_frame_equal(processed_df, expected_df)
+
+        expected_issues_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["WES NGS"] * 2,
+                "Specimen Identifier": ["SP-250129R0043", "SP-250128R0042"],
+                "Test Directory Test Code": [pd.NA, "R208.1|R209.1"],
+                "sample_id": ["250129R0043", "250128R0042"],
+                "R_codes": [[], ["R208", "R209"]],
+            }
+        )
+
+        pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
 
 
 class TestPreprocessReportDf:

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -153,7 +153,7 @@ def test_get_matching_projects(mock_find_projects):
         {"id": "proj-2", "describe": {"name": "002_bar_CEN"}},
     ]
     result = ceh.get_matching_projects(["CEN"])
-    assert result == [("proj-1", "002_foo_CEN"), ("proj-2", "002_bar_CEN")]
+    assert result == {"proj-1": "002_foo_CEN", "proj-2": "002_bar_CEN"}
 
 
 @patch("utils.clarity_extract_handler.dxpy.find_data_objects")
@@ -188,35 +188,6 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
     assert records == expected_list
 
 
-def test_find_file_name_no_files_found(monkeypatch):
-    # No files returned
-    monkeypatch.setattr(ceh.dxpy, "find_data_objects", lambda **kwargs: [])
-    assert ceh.find_file_name("SP-24010R0031*") is None
-
-
-def test_find_file_name_multiple_files(monkeypatch):
-    # Multiple files returned -> should return None
-    monkeypatch.setattr(
-        ceh.dxpy,
-        "find_data_objects",
-        lambda **kwargs: [
-            {"describe": {"name": "SP-24010R0031-CEN_R208.1_1.xlsx"}},
-            {"describe": {"name": "SP-24010R0031-CEN_R208.1_2.xlsx"}},
-        ],
-    )
-    assert ceh.find_file_name("SP-24010R0031*") is None
-
-
-def test_find_file_name_single_file(monkeypatch):
-    # Single file returned -> should return that filename
-    monkeypatch.setattr(
-        ceh.dxpy,
-        "find_data_objects",
-        lambda **kwargs: [{"describe": {"name": "SP-24010R0031-CEN_R208.1_1.xlsx"}}],
-    )
-    assert ceh.find_file_name("SP-24010R0031*") == "SP-24010R0031-CEN_R208.1_1.xlsx"
-
-
 class TestExtractAssayFromFilename:
     """Test extracting assay from filename."""
 
@@ -231,33 +202,6 @@ class TestExtractAssayFromFilename:
 
     def test_unknown_assay(self):
         assert ceh.extract_assay_from_filename("file_UNKNOWN_123.xlsx") is None
-
-
-class TestFindFileName:
-    """Test finding file names in a project."""
-
-    def test_no_files(self, monkeypatch):
-        monkeypatch.setattr(ceh.dxpy, "find_data_objects", lambda **kwargs: [])
-        assert ceh.find_file_name("sample*") is None
-
-    def test_multiple_files(self, monkeypatch):
-        monkeypatch.setattr(
-            ceh.dxpy,
-            "find_data_objects",
-            lambda **kwargs: [
-                {"describe": {"name": "sample1.xlsx"}},
-                {"describe": {"name": "sample2.xlsx"}},
-            ],
-        )
-        assert ceh.find_file_name("sample*") is None
-
-    def test_single_file(self, monkeypatch):
-        monkeypatch.setattr(
-            ceh.dxpy,
-            "find_data_objects",
-            lambda **kwargs: [{"describe": {"name": "sample1.xlsx"}}],
-        )
-        assert ceh.find_file_name("sample*") == "sample1.xlsx"
 
 
 class TestRCodeMatching:
@@ -316,3 +260,259 @@ class TestRCodeMatching:
         # function is case-sensitive; lower-case report code should not match upper-case list
         row = example_df_lowercase_r_codes.iloc[0]
         assert ceh.is_report_code_in_list(row) is False
+
+
+class TestPreProcessClarityExtract:
+    """Test preprocessing of clarity extract DataFrame."""
+
+    def test_preprocess_clarity_df_same_R_code_multiple_test_mode(self):
+        example_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["RARE DISEASE NGS ANALYSIS"],
+                "Specimen Identifier": [
+                    "SP-250123R0037",
+                ],
+                "Test Directory Test Code": ["R228.1|R228.2"],
+            }
+        )
+
+        processed_df = ceh.preprocess_clarity_extract(example_df)
+
+        # Check that paths are correctly created
+        expected_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["RARE DISEASE NGS ANALYSIS"],
+                "Specimen Identifier": [
+                    "SP-250123R0037",
+                ],
+                "Test Directory Test Code": ["R228.1|R228.2"],
+                "sample_id": [
+                    "250123R0037",
+                ],
+                "R_codes": [
+                    ["R228"],
+                ],
+            }
+        )
+
+        pd.testing.assert_frame_equal(processed_df, expected_df)
+
+    def test_preprocess_clarity_df_single_R_code(self):
+        example_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["CEN NGS"] * 2,
+                "Specimen Identifier": ["SP-250126R0040", "SP-250127R0041"],
+                "Test Directory Test Code": ["R208.1", "R149.1"],
+            }
+        )
+
+        processed_df = ceh.preprocess_clarity_extract(example_df)
+
+        # Check that paths are correctly created
+        expected_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["CEN NGS"] * 2,
+                "Specimen Identifier": ["SP-250126R0040", "SP-250127R0041"],
+                "Test Directory Test Code": ["R208.1", "R149.1"],
+                "sample_id": [
+                    "250126R0040",
+                    "250127R0041",
+                ],
+                "R_codes": [
+                    ["R208"],
+                    ["R149"],
+                ],
+            }
+        )
+
+        pd.testing.assert_frame_equal(processed_df, expected_df)
+
+    def test_preprocess_clarity_df_no_R_code(self):
+        example_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": ["WES NGS"] * 2,
+                "Specimen Identifier": ["SP-250128R0042", "SP-250129R0043"],
+                "Test Directory Test Code": [pd.NA, pd.NA],
+            }
+        )
+
+        processed_df = ceh.preprocess_clarity_extract(example_df)
+
+        # Check that paths are correctly created
+        expected_df = pd.DataFrame(
+            {
+                "Beaker Procedure Name": pd.Series([], dtype="object"),
+                "Specimen Identifier": pd.Series([], dtype="object"),
+                "Test Directory Test Code": pd.Series([], dtype="object"),
+                "sample_id": pd.Series([], dtype="object"),
+                "R_codes": pd.Series([], dtype="object"),
+            }
+        )
+
+        pd.testing.assert_frame_equal(processed_df, expected_df)
+
+
+class TestPreprocessReportDf:
+    """Test preprocessing of report DataFrame."""
+
+    def test_preprocess_report_df(self):
+        example_df = pd.DataFrame(
+            {
+                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
+                "sample_id": ["24123R0012"],
+                "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
+            }
+        )
+
+        base_path = "/test_workbooks/"
+        processed_df = ceh.preprocess_report_df(example_df, base_path)
+
+        expected_df = pd.DataFrame(
+            {
+                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
+                "sample_id": ["24123R0012"],
+                "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
+                "Assay": ["CEN"],
+                "path": [Path("/test_workbooks/CEN/Run folders/240516_A01303_0387_BH7F2WDRX5_CEN/129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx")],
+                "instrument_id": ["129740955"],
+                "full_sample_id": ["129740955-24123R0012"],
+                "report_r_code": ["R228.1"],
+            }
+        )
+
+        pd.testing.assert_frame_equal(processed_df, expected_df)
+
+
+class TestFilteringReports:
+    """Test filtering of reports DataFrame."""
+    def test_filtering_reports_cnv_code(self):
+        example_df = pd.DataFrame(
+            {
+                "file_name": [
+                    "129740957-24123R0014-24NGCEN42-9527-F-99347389_R228.1_SNV_1.xlsx",
+                    "129740957-24123R0014-24NGCEN42-9527-F-99347389_R228.1_CNV_1.xlsx",
+                ],
+                "sample_id": [
+                    "24123R0014",
+                    "24123R0014",
+                ],
+                "report_r_code": [
+                    "R228.1",
+                    "R228.1",
+                ],
+                "R_codes": [
+                    ["R228"],
+                    ["R228"]
+                ]
+            }
+        )
+
+        filtered_df, missing_data_df = ceh.filtering_reports(example_df)
+
+        expected_filtered_df = pd.DataFrame(
+            {
+                "file_name": [
+                    "129740957-24123R0014-24NGCEN42-9527-F-99347389_R228.1_SNV_1.xlsx",
+                ],
+                "sample_id": [
+                    "24123R0014",
+                ],
+                "report_r_code": [
+                    "R228.1",
+                ],
+                "R_codes": [
+                    ["R228"]
+                ],
+            }
+        )
+
+        expected_missing_data_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object')
+        })
+
+        pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+
+    def test_filtering_r_code_mismatch(self):
+        example_df = pd.DataFrame(
+            {
+                "file_name": [
+                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx",
+                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
+                ],
+                "sample_id": [
+                    "24123R0015",
+                    "24123R0015",
+                ],
+                "report_r_code": [
+                    "R228.1",
+                    "R149.1",
+                ],
+                "R_codes": [
+                    ["R228"],
+                    ["R228"]
+                ]
+            }
+        )
+
+        filtered_df, missing_data_df = ceh.filtering_reports(example_df)
+
+        expected_filtered_df = pd.DataFrame({
+            'file_name': ["129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx"],
+            'sample_id': ["24123R0015"],
+            'report_r_code': ["R228.1"],
+            'R_codes': [["R228"]]
+        })
+
+        pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
+
+        expected_filtered_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object')
+        })
+
+        pd.testing.assert_frame_equal(missing_data_df, expected_filtered_df)
+
+    def test_filtering_no_filename(self):
+        example_df = pd.DataFrame(
+            {
+                "file_name": [
+                    pd.NA,
+                ],
+                "sample_id": [
+                    "24123R0015",
+                ],
+                "report_r_code": [
+                    pd.NA
+                ],
+                "R_codes": [
+                    ["R228"],
+                ]
+            }
+        )
+
+        filtered_df, missing_data_df = ceh.filtering_reports(example_df)
+        expected_filtered_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object')
+        })
+
+        pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
+
+        expected_missing_data_df = pd.DataFrame(
+            {
+                "file_name": [pd.NA],
+                "sample_id": ["24123R0015"],
+                "report_r_code": [pd.NA],
+                "R_codes": [["R228"]],
+            }
+        )
+
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -373,7 +373,10 @@ def filtering_reports(report_df):
     """
     if report_df is None or report_df.empty:
         print("Report DataFrame is empty or None. Skipping filtering.")
-        return report_df
+        return (
+            pd.DataFrame(columns=["file_name", "sample_id", "report_r_code", "R_codes"]),
+            report_df,
+        )
 
     # Remove rows with no DX data (as they would be silently removed by
     # the R code matching below)
@@ -387,19 +390,24 @@ def filtering_reports(report_df):
 
     # Check R code matches
     report_df = report_df[~missing_mask].copy()
-    report_df["rcode_match"] = report_df.apply(is_report_code_in_list, axis=1)
-    # Filter rows where R code doesn't match
-    report_df = report_df[report_df["rcode_match"]].copy()
-    # clean up by dropping the rcode_match column
-    if "rcode_match" in report_df.columns:
-        report_df = report_df.drop(columns=["rcode_match"])
-    # Filter out rows where filename contains _CNV_ or _mosaic_
-    if "file_name" in report_df.columns:
+
+    if not report_df.empty:
+        report_df["rcode_match"] = report_df.apply(is_report_code_in_list, axis=1)
+        # Filter rows where R code doesn't match
+        report_df = report_df[report_df["rcode_match"]].copy()
+        # clean up by dropping the rcode_match column
+        report_df = report_df.drop(columns=["rcode_match"], errors="ignore")
+        # Filter out rows where filename contains _CNV_ or _mosaic_
         filtered_df = report_df[
             ~report_df["file_name"].str.contains(r"_(CNV|mosaic)_", na=False)
         ].copy()
     else:
-        filtered_df = report_df.copy()
+        filtered_df = pd.DataFrame(columns=report_df.columns)
+
+    # If we've filtered all rows out, ensure we return empty df with expected
+    # columns
+    if filtered_df.empty:
+        filtered_df = pd.DataFrame(columns=["file_name", "sample_id", "report_r_code", "R_codes"])
 
     return filtered_df, missing_data_df
 

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -37,6 +37,50 @@ def open_files(clarity):
     return clarity_df
 
 
+def preprocess_clarity_extract(clarity_df):
+    """
+    Preprocess the clarity extract DataFrame by adding necessary columns and cleaning data.
+
+    Inputs:
+        clarity_df (pd.DataFrame): DataFrame containing clarity extract information.
+    Outputs:
+        clarity_df (pd.DataFrame): Preprocessed DataFrame with additional
+        sample_id and R_codes columns.
+    """
+    # Split out sample ID to remove "SP-" prefix
+    clarity_df["sample_id"] = (
+        clarity_df["Specimen Identifier"].str.split("-").str[1]
+    )
+
+    # Split unique base R codes into a list
+    clarity_df["R_codes"] = (
+        clarity_df["Test Directory Test Code"]
+        .fillna("")
+        .str.split("|")
+        .apply(
+            lambda codes: sorted(
+                {re.sub(r"\.\d+$", "", c.strip()) for c in codes if c}
+            )
+        )
+    )
+
+    missing_r_codes_df = clarity_df[clarity_df["R_codes"].str.len() == 0].copy()
+    multiple_r_codes_df = clarity_df[clarity_df["R_codes"].str.len() > 1].copy()
+
+    if not missing_r_codes_df.empty:
+        print("Samples with missing R codes in Clarity extract:")
+        print(missing_r_codes_df[["Specimen Identifier", "R_codes"]])
+
+    if not multiple_r_codes_df.empty:
+        print("Samples with multiple R codes in Clarity extract:")
+        print(multiple_r_codes_df[["Specimen Identifier", "R_codes"]])
+
+    # Keep only samples with one R code
+    clarity_df = clarity_df[clarity_df["R_codes"].str.len() == 1]
+
+    return clarity_df
+
+
 def get_matching_projects(assays):
     """
     Retrieve project IDs matching specific name patterns.
@@ -45,20 +89,24 @@ def get_matching_projects(assays):
     assays : list
         The list of assay types to filter projects (e.g., ['CEN', 'TWE']).
     Outputs:
-    matching_projects_tuple_list: list
-        A list of tuples containing project IDs and their names.
-        Each tuple is in the format (project_id, project_name).
+    matching_projects_dict: dict
+        A dictionary mapping project IDs to project names.
     """
     query_str_for_assays = "|".join(assays)
     re_pattern = rf"^002.*_(?:{query_str_for_assays})$"
+
     matching_projects = list(
-        dxpy.find_projects(name={"regexp": re_pattern}, describe=True)
+        dxpy.find_projects(
+            name={"regexp": re_pattern},
+            describe={"fields": {"name": True}}
+        )
     )
-    matching_projects_tuple_list = [
-        (proj["id"], proj["describe"]["name"]) for proj in matching_projects
-    ]
-    print(f"Found {len(matching_projects_tuple_list)} matching projects.")
-    return matching_projects_tuple_list
+    matching_projects_dict = {
+        proj["id"]: proj["describe"]["name"] for proj in matching_projects
+    }
+    print(f"Found {len(matching_projects_dict.keys())} matching projects.")
+
+    return matching_projects_dict
 
 
 def query_reports_for_project(project_id, sample_ids):
@@ -94,7 +142,10 @@ def query_reports_for_project(project_id, sample_ids):
         )
         # If no files found, return empty records
         if not matching_files:
-            print(f"No files found for project {project_id} with pattern {pattern}")
+            print(
+                f"No files found for project {project_id} with pattern"
+                f" {pattern}"
+            )
             return records
         for file in matching_files:
             file_name = file["describe"]["name"]
@@ -140,40 +191,54 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
         DataFrame containing the merged results with additional columns.
     """
     sample_ids = df["sample_id"].tolist()
-    project_info = get_matching_projects(assays)
-    project_dict = dict(project_info)
+    project_dict = get_matching_projects(assays)
 
     # Chunk sample IDs to manage search load
     chunks = [
-        sample_ids[i : i + chunk_size] for i in range(0, len(sample_ids), chunk_size)
+        sample_ids[i : i + chunk_size]
+        for i in range(0, len(sample_ids), chunk_size)
+    ]
+
+    tasks = [
+        (proj_id, chunk) for proj_id in project_dict.keys() for chunk in chunks
     ]
 
     all_records = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = []
-        for project_id in project_dict.keys():
-            for chunk in chunks:
-                futures.append(
-                    executor.submit(query_reports_for_project, project_id, chunk)
-                )
+        futures = {
+            executor.submit(query_reports_for_project, pid, chunk): (
+                pid,
+                chunk,
+            )
+            for pid, chunk in tasks
+        }
 
         for future in as_completed(futures):
+            pid, chunk = futures[future]
             try:
-                records = future.result()
-                all_records.extend(records)
+                result = future.result()
+                if result:
+                    all_records.extend(result)
             except Exception as e:
-                print(f"Error in future: {e}")
+                print(f"Error fetching reports for project {pid}: {e}")
 
     # Add project names to records
     for record in all_records:
-        record["project_name"] = project_dict.get(record["project_id"], "Unknown")
+        record["project_name"] = project_dict.get(
+            record["project_id"], "Unknown"
+        )
 
     # Create a DataFrame from the records
     records_df = pd.DataFrame(all_records)
     if records_df.empty:
         print("No records found for the given sample IDs.")
-        empty_cols = {"file_name": pd.NA, "project_id": pd.NA, "project_name": pd.NA}
+        empty_cols = {
+            "file_name": pd.NA,
+            "project_id": pd.NA,
+            "project_name": pd.NA,
+        }
         return df.copy().assign(**empty_cols)
+
     # Merge with the original df to retain additional columns
     merged_df = pd.merge(df, records_df, on="sample_id", how="left")
     print(f"Merged DataFrame shape: {merged_df.shape}")
@@ -229,7 +294,8 @@ def create_path(filename, base_path, assay, run):
     # Return None if run_name extraction failed
     if run_name is None:
         print(
-            f"Warning: Could not extract run_name from '{run}' for filename {filename}. Returning None."
+            f"Warning: Could not extract run_name from '{run}' for filename"
+            f" {filename}. Returning None."
         )
         return None
 
@@ -244,32 +310,11 @@ def create_path(filename, base_path, assay, run):
         path = base_path / "WES" / run_folder / filename
     else:
         print(
-            f"Warning: Unknown assay '{assay}' for filename {filename}. Returning None."
+            f"Warning: Unknown assay '{assay}' for filename {filename}."
+            " Returning None."
         )
         return None
     return path
-
-
-def find_file_name(search_query):
-    """
-    Find the file name for a given search query on DNAnexus
-    Inputs:
-
-        search_query (str): search query for file name when searching DNAnexus
-    Outputs:
-        filename (str): a file name, or None if no or multiple matches found
-    """
-    files = list(
-        dxpy.find_data_objects(
-            name=search_query, name_mode="glob", describe={"fields": {"name": True}}
-        )
-    )
-    filenames = [file.get("describe").get("name") for file in files]
-    if len(filenames) != 1:
-        print(f"{search_query} returned multiple/no files")
-        return None
-    else:
-        return filenames[0]
 
 
 def is_report_code_in_list(row) -> bool:
@@ -284,35 +329,24 @@ def is_report_code_in_list(row) -> bool:
     r_codes = row.get("R_codes", [])
     report_code = row.get("report_r_code")
 
-    # Check if report_code is missing
-    if pd.isna(report_code):
+    if pd.isna(report_code) or r_codes is None:
         return False
 
-    # Handle different types of r_codes input
-    if pd.isna(r_codes) or r_codes == [] or r_codes == "[]":
-        return False
-
-    # Convert string representation of list to actual list
+    # Convert string representation like "['R337']" to actual list (if reading
+    # from file)
     if isinstance(r_codes, str):
         try:
-            # Use ast.literal_eval instead of json.loads for Python literal evaluation
-            r_codes_list = ast.literal_eval(r_codes)
-        except (ValueError, SyntaxError) as e:
-            # If parsing fails, assume it's not a valid list
-            raise ValueError(f"Invalid R_codes format: {r_codes}") from e
-    elif isinstance(r_codes, list):
-        r_codes_list = r_codes
-    else:
-        raise TypeError(f"Unexpected type for R_codes: {type(r_codes)}")
+            r_codes = ast.literal_eval(r_codes)
+        except Exception:
+            return False
 
-    # Handle empty list
-    if not r_codes_list:
+    if not isinstance(r_codes, (list, tuple)) or len(r_codes) == 0:
         return False
 
     # Normalize and compare
-    target = re.sub(r"\.\d+", "", str(report_code))
+    target = re.sub(r"\.\d+$", "", str(report_code)).strip()
     normalized_codes = [
-        re.sub(r"\.\d+", "", str(c)) for c in r_codes_list
+        re.sub(r"\.\d+$", "", str(c)).strip() for c in r_codes if c
     ]
 
     return target in normalized_codes
@@ -355,20 +389,36 @@ def filtering_reports(report_df):
         print("Report DataFrame is empty or None. Skipping filtering.")
         return report_df
 
+    # Remove rows with no DX data (as they would be silently removed by
+    # the R code matching below)
+    missing_mask = (
+        report_df["file_name"].isna() |
+        report_df["report_r_code"].isna()
+    )
+    missing_data_df = report_df[missing_mask].copy()
+    if not missing_data_df.empty:
+        print(f"{missing_data_df.shape[0]} rows have missing DNAnexus data.")
+
+    # Check R code matches
+    report_df = report_df[~missing_mask].copy()
     report_df["rcode_match"] = report_df.apply(is_report_code_in_list, axis=1)
     # Filter rows where R code doesn't match
     report_df = report_df[report_df["rcode_match"]].copy()
     # clean up by dropping the rcode_match column
-    report_df = report_df.drop(columns=["rcode_match"])
+    if "rcode_match" in report_df.columns:
+        report_df = report_df.drop(columns=["rcode_match"])
     # Filter out rows where filename contains _CNV_ or _mosaic_
-    filtered_df = report_df[
-        ~report_df["file_name"].str.contains(r"_(CNV|mosaic)_", na=False)
-    ]
+    if "file_name" in report_df.columns:
+        filtered_df = report_df[
+            ~report_df["file_name"].str.contains(r"_(CNV|mosaic)_", na=False)
+        ].copy()
+    else:
+        filtered_df = report_df.copy()
 
-    return filtered_df
+    return filtered_df, missing_data_df
 
 
-def remove_missing_and_multiple_reports(report_df):
+def remove_multiple_reports(report_df):
     """
     Remove reports with missing or multiple files.
 
@@ -376,64 +426,49 @@ def remove_missing_and_multiple_reports(report_df):
         report_df (pd.DataFrame): DataFrame containing report information with a 'file_name' column.
 
     Outputs:
-        report_df_filtered (pd.DataFrame): Filtered DataFrame excluding rows with missing or multiple files.
-        missing_data_df (pd.DataFrame): DataFrame containing rows with missing data in 'file_name' or 'R_codes'.
+        report_df_filtered (pd.DataFrame): Filtered DataFrame excluding rows with multiple files.
         multiple_reports_df (pd.DataFrame): DataFrame containing rows with multiple reports per assay.
     """
-
-    missing_data = report_df["file_name"].isna() | report_df["R_codes"].isna()
-    missing_data_df = report_df[missing_data]
-    if missing_data.any():
-        print(
-            f"Warning: {missing_data.sum()} rows have missing data in 'file_name' or 'R_codes'."
-        )
-
-    # Mask to filter out rows with NaN R codes and empty file names which aren't '' just blank
-    report_df = report_df.dropna(subset=["file_name", "report_r_code"]).copy()
-    print(
-        f"After filtering out NaN R codes and empty file names: {report_df.shape[0]} rows remaining"
-    )
-
-    # Drop duplicates on all columns except certain ones
-    cols_to_check = [col for col in report_df.columns if col not in ["R_codes"]]
+    # Drop duplicates
+    cols_to_check = [c for c in report_df.columns if c != "R_codes"]
     report_df = report_df.drop_duplicates(subset=cols_to_check).copy()
     print(f"After dropping duplicates: {report_df.shape[0]} rows remaining")
 
+
     # Save rows with multiple reports per assay to a separate file
-    multiple_reports = (
+    counts = (
         report_df.groupby(["sample_id", "Assay", "report_r_code"])
         .size()
         .reset_index(name="report_count")
-    ).copy()
-    multiple_reports = multiple_reports[multiple_reports["report_count"] > 1]
-    multiple_reports_df = pd.DataFrame()
+    )
+
+    multiple_reports = counts.query("report_count > 1")
+    single_reports = counts.query("report_count == 1")
+
     if not multiple_reports.empty:
-        print(f"Samples with multiple reports per assay: {multiple_reports.shape[0]}")
-        # Filter the original report_df to keep only samples with single reports
-        multiple_reports_df = pd.merge(
-            report_df,
-            multiple_reports[["sample_id", "Assay", "report_r_code"]],
-            on=["sample_id", "Assay", "report_r_code"],
-            how="inner",
-        ).copy()
+        print(
+            "Samples with multiple reports per assay:"
+            f" {multiple_reports.shape[0]}"
+        )
+        multiple_reports_df = (
+            report_df.merge(
+                multiple_reports[["sample_id", "Assay", "report_r_code"]],
+                on=["sample_id", "Assay", "report_r_code"],
+                how="inner"
+            )
+        )
     else:
         print("No samples with multiple reports per assay found.")
+        multiple_reports_df = pd.DataFrame(columns=report_df.columns)
 
-    # Remove rows with multiple reports per assay
-    report_df_grouped = (
-        report_df.groupby(["sample_id", "Assay", "report_r_code"])
-        .size()
-        .reset_index(name="report_count")
-    ).copy()
-    single_reports_df = report_df_grouped[report_df_grouped["report_count"] == 1]
     # Filter the original report_df to keep only samples with single reports
-    report_df_filtered = pd.merge(
-        report_df,
-        single_reports_df[["sample_id", "Assay", "report_r_code"]],
+    report_df_filtered = report_df.merge(
+        single_reports[["sample_id", "Assay", "report_r_code"]],
         on=["sample_id", "Assay", "report_r_code"],
-        how="inner",
-    ).copy()
-    return report_df_filtered, missing_data_df, multiple_reports_df
+        how="inner"
+    )
+
+    return report_df_filtered, multiple_reports_df
 
 
 def preprocess_report_df(report_df, base_path):
@@ -447,26 +482,16 @@ def preprocess_report_df(report_df, base_path):
     Outputs:
         report_df (pd.DataFrame): Preprocessed DataFrame with additional columns.
     """
-    # Split R codes into a list
-    report_df["R_codes"] = (
-        report_df["Test Directory Test Code"].fillna("").str.split("|")
-    )
-
-    # remove decimal points from R codes
-    report_df["R_codes"] = report_df["R_codes"].apply(
-        lambda x: [
-            re.sub(r"\.\d+", "", code)
-            for code in x
-            if isinstance(code, str) and code.startswith("R")
-        ]
-    )
-
     # Extract assay from filename
-    report_df["Assay"] = report_df["file_name"].apply(extract_assay_from_filename)
+    report_df["Assay"] = report_df["file_name"].apply(
+        extract_assay_from_filename
+    )
 
     # Add the path to the processed reports
     report_df["path"] = report_df.apply(
-        lambda x: create_path(x["file_name"], base_path, x["Assay"], x["project_name"]),
+        lambda x: create_path(
+            x["file_name"], base_path, x["Assay"], x["project_name"]
+        ),
         axis=1,
     )
 
@@ -476,7 +501,9 @@ def preprocess_report_df(report_df, base_path):
         report_df["instrument_id"] + "-" + report_df["sample_id"]
     )
     # create report_r_code column from file_name
-    report_df["report_r_code"] = report_df["file_name"].str.extract(r"_(R\d+\.\d+)_")[0]
+    report_df["report_r_code"] = report_df["file_name"].str.extract(
+        r"_(R\d+\.\d+)_"
+    )[0]
 
     return report_df
 
@@ -499,19 +526,37 @@ def handle_clarity_extract(
     """
     # Read data into dataframes
     clarity_df = open_files(clarity_extract_path)
+    clarity_df_preprocessed = preprocess_clarity_extract(clarity_df)
 
-    # Process data to construct a path for each specimen
-    # create df with column by splitting the Beaker Procedure Name to create a new column for assay
-    clarity_df["sample_id"] = clarity_df["Specimen Identifier"].str.split("-").str[1]
-    report_df = pd.DataFrame()
+    if clarity_df_preprocessed.empty:
+        print(
+            "No valid samples with single R codes found in Clarity extract."
+            " Returning empty DataFrames."
+        )
+        empty_cols = {
+            "file_name": pd.NA,
+            "project_id": pd.NA,
+            "project_name": pd.NA,
+            "R_codes": pd.NA,
+            "Assay": pd.NA,
+            "path": pd.NA,
+            "instrument_id": pd.NA,
+            "full_sample_id": pd.NA,
+            "report_r_code": pd.NA,
+        }
+        empty_df = pd.DataFrame(
+            columns=list(clarity_df.columns) + list(empty_cols.keys())
+        )
+        return empty_df, empty_df.copy(), empty_df.copy()
 
     print(f"Processing assays: {assays}")
-    report_df = fetch_all_reports(clarity_df, assays)
+    report_df = fetch_all_reports(clarity_df_preprocessed, assays)
 
     # Add check for empty DataFrame
     if report_df.empty:
         print(
-            "No reports found after fetching from DNAnexus. Returning empty DataFrames."
+            "No reports found after fetching from DNAnexus. Returning empty"
+            " DataFrames."
         )
         empty_cols = {
             "file_name": pd.NA,
@@ -534,12 +579,17 @@ def handle_clarity_extract(
     # Preprocess report_df
     report_df = preprocess_report_df(report_df, base_path)
     print(f"Report DataFrame after preprocessing: {report_df.shape[0]} rows")
+
     # Filter out all rows where filename contains _CNV_ or _mosaic_
-    report_df = filtering_reports(report_df)
+    report_df, missing_data_df = filtering_reports(report_df)
+    print(
+        f"Report DataFrame after filtering CNV/mosaic and R code mismatches:"
+        f" {report_df.shape[0]} rows"
+    )
 
     # Remove missing and multiple reports
-    report_df_filtered, missing_data_df, multiple_reports_df = (
-        remove_missing_and_multiple_reports(report_df)
+    report_df_filtered, multiple_reports_df = (
+        remove_multiple_reports(report_df)
     )
 
     return report_df_filtered, missing_data_df, multiple_reports_df

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -46,10 +46,13 @@ def preprocess_clarity_extract(clarity_df):
     Outputs:
         clarity_df (pd.DataFrame): Preprocessed DataFrame with additional
         sample_id and R_codes columns.
+        clarity_issues_df (pd.DataFrame): DataFrame containing samples with missing or multiple R codes.
     """
     # Split out sample ID to remove "SP-" prefix
     clarity_df["sample_id"] = (
-        clarity_df["Specimen Identifier"].str.split("-").str[1]
+        clarity_df["Specimen Identifier"]
+        .str.split("-")
+        .apply(lambda parts: parts[1] if len(parts) > 1 else None)
     )
 
     # Split unique base R codes into a list
@@ -66,19 +69,18 @@ def preprocess_clarity_extract(clarity_df):
 
     missing_r_codes_df = clarity_df[clarity_df["R_codes"].str.len() == 0].copy()
     multiple_r_codes_df = clarity_df[clarity_df["R_codes"].str.len() > 1].copy()
+    clarity_issues_df = pd.concat(
+        [missing_r_codes_df, multiple_r_codes_df], ignore_index=True
+    )
 
     if not missing_r_codes_df.empty:
         print("Samples with missing R codes in Clarity extract:")
         print(missing_r_codes_df[["Specimen Identifier", "R_codes"]])
 
-    if not multiple_r_codes_df.empty:
-        print("Samples with multiple R codes in Clarity extract:")
-        print(multiple_r_codes_df[["Specimen Identifier", "R_codes"]])
-
     # Keep only samples with one R code
     clarity_df = clarity_df[clarity_df["R_codes"].str.len() == 1]
 
-    return clarity_df
+    return clarity_df, clarity_issues_df
 
 
 def get_matching_projects(assays):
@@ -202,21 +204,21 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
     all_records = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
-            executor.submit(query_reports_for_project, pid, chunk): (
-                pid,
+            executor.submit(query_reports_for_project, proj_id, chunk): (
+                proj_id,
                 chunk,
             )
-            for pid, chunk in tasks
+            for proj_id, chunk in tasks
         }
 
         for future in as_completed(futures):
-            pid, chunk = futures[future]
+            proj_id, chunk = futures[future]
             try:
                 result = future.result()
                 if result:
                     all_records.extend(result)
             except Exception as e:
-                print(f"Error fetching reports for project {pid}: {e}")
+                print(f"Error fetching reports for project {proj_id}: {e}")
 
     # Add project names to records
     for record in all_records:
@@ -370,6 +372,7 @@ def filtering_reports(report_df):
 
     Outputs:
         filtered_df (pd.DataFrame): Filtered DataFrame excluding rows with '_CNV_' or '_mosaic_' in 'file_name'.
+        missing_data_df (pd.DataFrame): DataFrame containing rows with missing DNAnexus data.
     """
     if report_df is None or report_df.empty:
         print("Report DataFrame is empty or None. Skipping filtering.")
@@ -408,6 +411,9 @@ def filtering_reports(report_df):
     # columns
     if filtered_df.empty:
         filtered_df = pd.DataFrame(columns=["file_name", "sample_id", "report_r_code", "R_codes"])
+
+    if missing_data_df is None:
+        missing_data_df = pd.DataFrame(columns=["file_name", "sample_id", "report_r_code", "R_codes"])
 
     return filtered_df, missing_data_df
 
@@ -498,7 +504,7 @@ def preprocess_report_df(report_df, base_path):
 
 def handle_clarity_extract(
     clarity_extract_path, assays, base_path
-) -> tuple[DataFrame, DataFrame, DataFrame]:
+):
     """
     Main function to handle clarity extract and return paths to workbooks
     Inputs:
@@ -511,10 +517,13 @@ def handle_clarity_extract(
         missing_data_df (pd.DataFrame): DataFrame of workbooks with missing data
         multiple_reports_df (pd.DataFrame): DataFrame of workbooks
             with multiple workbooks per assay
+        clarity_issues_df (pd.DataFrame): DataFrame of samples with clarity issues
     """
     # Read data into dataframes
     clarity_df = open_files(clarity_extract_path)
-    clarity_df_preprocessed = preprocess_clarity_extract(clarity_df)
+    clarity_df_preprocessed, clarity_issues_df = preprocess_clarity_extract(
+        clarity_df
+    )
 
     if clarity_df_preprocessed.empty:
         print(
@@ -579,4 +588,4 @@ def handle_clarity_extract(
         remove_multiple_reports(report_df)
     )
 
-    return report_df_filtered, missing_data_df, multiple_reports_df
+    return report_df_filtered, missing_data_df, multiple_reports_df, clarity_issues_df

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -142,10 +142,7 @@ def query_reports_for_project(project_id, sample_ids):
         )
         # If no files found, return empty records
         if not matching_files:
-            print(
-                f"No files found for project {project_id} with pattern"
-                f" {pattern}"
-            )
+            print(f"No files found for project {project_id} with pattern {pattern}")
             return records
         for file in matching_files:
             file_name = file["describe"]["name"]
@@ -195,8 +192,7 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     # Chunk sample IDs to manage search load
     chunks = [
-        sample_ids[i : i + chunk_size]
-        for i in range(0, len(sample_ids), chunk_size)
+        sample_ids[i : i + chunk_size] for i in range(0, len(sample_ids), chunk_size)
     ]
 
     tasks = [
@@ -224,19 +220,13 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     # Add project names to records
     for record in all_records:
-        record["project_name"] = project_dict.get(
-            record["project_id"], "Unknown"
-        )
+        record["project_name"] = project_dict.get(record["project_id"], "Unknown")
 
     # Create a DataFrame from the records
     records_df = pd.DataFrame(all_records)
     if records_df.empty:
         print("No records found for the given sample IDs.")
-        empty_cols = {
-            "file_name": pd.NA,
-            "project_id": pd.NA,
-            "project_name": pd.NA,
-        }
+        empty_cols = {"file_name": pd.NA, "project_id": pd.NA, "project_name": pd.NA}
         return df.copy().assign(**empty_cols)
 
     # Merge with the original df to retain additional columns
@@ -293,10 +283,7 @@ def create_path(filename, base_path, assay, run):
 
     # Return None if run_name extraction failed
     if run_name is None:
-        print(
-            f"Warning: Could not extract run_name from '{run}' for filename"
-            f" {filename}. Returning None."
-        )
+        print(f"Warning: Could not extract run_name from '{run}' for filename {filename}. Returning None.")
         return None
 
     # Build path depending on assay
@@ -310,8 +297,7 @@ def create_path(filename, base_path, assay, run):
         path = base_path / "WES" / run_folder / filename
     else:
         print(
-            f"Warning: Unknown assay '{assay}' for filename {filename}."
-            " Returning None."
+            f"Warning: Unknown assay '{assay}' for filename {filename}. Returning None."
         )
         return None
     return path
@@ -483,15 +469,11 @@ def preprocess_report_df(report_df, base_path):
         report_df (pd.DataFrame): Preprocessed DataFrame with additional columns.
     """
     # Extract assay from filename
-    report_df["Assay"] = report_df["file_name"].apply(
-        extract_assay_from_filename
-    )
+    report_df["Assay"] = report_df["file_name"].apply(extract_assay_from_filename)
 
     # Add the path to the processed reports
     report_df["path"] = report_df.apply(
-        lambda x: create_path(
-            x["file_name"], base_path, x["Assay"], x["project_name"]
-        ),
+        lambda x: create_path(x["file_name"], base_path, x["Assay"], x["project_name"]),
         axis=1,
     )
 
@@ -501,9 +483,7 @@ def preprocess_report_df(report_df, base_path):
         report_df["instrument_id"] + "-" + report_df["sample_id"]
     )
     # create report_r_code column from file_name
-    report_df["report_r_code"] = report_df["file_name"].str.extract(
-        r"_(R\d+\.\d+)_"
-    )[0]
+    report_df["report_r_code"] = report_df["file_name"].str.extract(r"_(R\d+\.\d+)_")[0]
 
     return report_df
 
@@ -555,8 +535,7 @@ def handle_clarity_extract(
     # Add check for empty DataFrame
     if report_df.empty:
         print(
-            "No reports found after fetching from DNAnexus. Returning empty"
-            " DataFrames."
+            "No reports found after fetching from DNAnexus. Returning empty DataFrames."
         )
         empty_cols = {
             "file_name": pd.NA,


### PR DESCRIPTION
- Add new function to pre-process Clarity extract to handle cases where multiple of the same R code but different test modes, and remove rows with multiple unique base R codes as these are not being handled in this version (fixes #24 )
  - Add unit tests
  - Only process Clarity extract if rows remain after preprocessing
- Change order of things to be able to report missing data in DNAnexus, as these were previously silently removed when checking if R code in file from DNAnexus is in list of R codes from Clarity
- Remove unused function `find_file_name()` and unit tests for this function

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/25)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skip processing and outputs when clarity extract is empty to avoid misleading files and errors.
  * More robust handling of code comparisons and missing values across flows.

* **Improvements**
  * Outputs separate clarity-issues CSV when issues are found and includes it in downstream reporting.
  * Clearer separation of preprocessing, fetching, filtering and deduplication; filtering now preserves and returns missing and duplicate report info.

* **Tests**
  * Expanded coverage for preprocessing, filtering and edge cases; expectations updated for new return shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->