### PR TITLE
Additional DB action to set 'DUP' for duplicate variants.

### DIFF
--- a/pandora.py
+++ b/pandora.py
@@ -233,6 +233,16 @@ def main():
     # Also exclude any variants meeting exclusion criteria set in the config
     if not args.hold_for_review:
         exclude = config["exclude"]
+        # Add DUP to the accession_id field for duplicates to exclude them
+        # from submission
+        print(
+            "Checking for duplicate variants... and setting accession_id to 'DUP'"
+            )
+        if not args.dry_run:
+            db.set_DUP_for_duplicate_null_accession(engine)
+        else:
+            print("Dry run specified. No changes will be made to the database.")
+
         cuh_df = db.select_variants_from_db("288359", engine, "NULL", exclude)
         nuh_df = db.select_variants_from_db("509428", engine, "NULL", exclude)
         print(

--- a/pandora.py
+++ b/pandora.py
@@ -239,7 +239,7 @@ def main():
             "Checking for duplicate variants... and setting accession_id to 'DUP'"
             )
         if not args.dry_run:
-            db.set_DUP_for_duplicate_null_accession(engine)
+            db.set_DUP_for_germline_duplicates(engine)
         else:
             print("Dry run specified. No changes will be made to the database.")
 

--- a/pandora.py
+++ b/pandora.py
@@ -235,10 +235,11 @@ def main():
         exclude = config["exclude"]
         # Add DUP to the accession_id field for duplicates to exclude them
         # from submission
-        print(
+
+        if not args.dry_run:
+            print(
             "Checking for duplicate variants... and setting accession_id to 'DUP'"
             )
-        if not args.dry_run:
             db.set_DUP_for_germline_duplicates(engine)
         else:
             print("Dry run specified. No changes will be made to the database.")

--- a/tests/test_database_actions.py
+++ b/tests/test_database_actions.py
@@ -5,8 +5,6 @@ from unittest.mock import call
 from freezegun import freeze_time
 import utils.database_actions as db
 import pandas as pd
-from itertools import chain
-
 
 class TestDatabaseEngine(unittest.TestCase):
     """
@@ -72,12 +70,21 @@ class TestDatabaseEngine(unittest.TestCase):
         # Patch engine.begin().__enter__() to return mock_conn
         mock_engine.begin.return_value.__enter__.return_value = mock_conn
         response = {"id": "SUB123456"}
+        db.add_submission_id_to_db(response, mock_engine, self.variants)
+
+        # Check execute was called once
+        mock_conn.execute.assert_called_once()
+
+        # Get the actual SQL text
+        call_args = mock_conn.execute.call_args
+        sql_text_obj = call_args[0][0]
+        actual_sql = str(sql_text_obj).strip()
+
         expected_sql = (
             "UPDATE testdirectory.inca SET submission_id = 'SUB123456' "
             "WHERE local_id in ('uid_12345', 'uid_67890')"
         )
-        db.add_submission_id_to_db(response, mock_engine, self.variants)
-        mock_conn.execute.assert_called_once_with(expected_sql)
+        self.assertEqual(actual_sql, expected_sql)
 
     def test_add_submission_id_to_db_if_error_returned(self):
         mock_engine = mock.MagicMock()
@@ -85,12 +92,20 @@ class TestDatabaseEngine(unittest.TestCase):
         # Patch engine.begin().__enter__() to return mock_conn
         mock_engine.begin.return_value.__enter__.return_value = mock_conn
         response = {"message": "No valid API key provided"}
+        db.add_submission_id_to_db(response, mock_engine, self.variants)
+        # Check execute was called once
+        mock_conn.execute.assert_called_once()
+        
+        # Get the actual SQL text
+        call_args = mock_conn.execute.call_args
+        sql_text_obj = call_args[0][0]
+        actual_sql = str(sql_text_obj).strip()
+
         expected_sql = (
             "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: No valid "
             "API key provided' WHERE local_id in ('uid_12345', 'uid_67890')"
         )
-        db.add_submission_id_to_db(response, mock_engine, self.variants)
-        mock_conn.execute.assert_called_once_with(expected_sql)
+        self.assertEqual(actual_sql, expected_sql)
 
     def test_add_error_to_db(self):
         # Prepare mock engine and connection

--- a/tests/test_database_actions.py
+++ b/tests/test_database_actions.py
@@ -75,16 +75,18 @@ class TestDatabaseEngine(unittest.TestCase):
         # Check execute was called once
         mock_conn.execute.assert_called_once()
 
-        # Get the actual SQL text
+        # Get the actual SQL text and params
         call_args = mock_conn.execute.call_args
         sql_text_obj = call_args[0][0]
+        params = call_args[0][1]
+
         actual_sql = str(sql_text_obj).strip()
 
-        expected_sql = (
-            "UPDATE testdirectory.inca SET submission_id = 'SUB123456' "
-            "WHERE local_id in ('uid_12345', 'uid_67890')"
-        )
-        self.assertEqual(actual_sql, expected_sql)
+        # Assert SQL uses parameter placeholders and params supplied
+        self.assertIn("UPDATE testdirectory.inca", actual_sql)
+        self.assertIn("submission_id = :sub_id", actual_sql)
+        self.assertIn("WHERE local_id = ANY(:variants)", actual_sql)
+        self.assertEqual(params, {"sub_id": "SUB123456", "variants": self.variants})
 
     def test_add_submission_id_to_db_if_error_returned(self):
         mock_engine = mock.MagicMock()
@@ -95,17 +97,19 @@ class TestDatabaseEngine(unittest.TestCase):
         db.add_submission_id_to_db(response, mock_engine, self.variants)
         # Check execute was called once
         mock_conn.execute.assert_called_once()
-        
-        # Get the actual SQL text
+
+        # Get the actual SQL text and params
         call_args = mock_conn.execute.call_args
         sql_text_obj = call_args[0][0]
+        params = call_args[0][1]
+
         actual_sql = str(sql_text_obj).strip()
 
-        expected_sql = (
-            "UPDATE testdirectory.inca SET clinvar_status = 'ERROR: No valid "
-            "API key provided' WHERE local_id in ('uid_12345', 'uid_67890')"
-        )
-        self.assertEqual(actual_sql, expected_sql)
+        # Assert SQL uses parameter placeholders and params supplied
+        self.assertIn("UPDATE testdirectory.inca", actual_sql)
+        self.assertIn("clinvar_status = :error", actual_sql)
+        self.assertIn("WHERE local_id = ANY(:variants)", actual_sql)
+        self.assertEqual(params, {"error": "ERROR: No valid API key provided", "variants": self.variants})
 
     def test_add_error_to_db(self):
         # Prepare mock engine and connection

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -224,7 +224,7 @@ def add_clinvar_submission_error_to_db(errors, engine):
 def set_DUP_for_germline_duplicates(engine):
     """
     Set accession_id = 'DUP' for all duplicate germline variants
-    (same chrom, pos, ref, alt, preferred_condition_name, organisation_id)
+    (same hgvsc, preferred_condition_name, organisation_id)
     where accession_id IS NULL and another duplicate exists with accession_id IS NOT NULL.
     """
     query = text("""

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -93,14 +93,18 @@ def add_submission_id_to_db(response, engine, variants):
         # Otherwise, update the inca table with an error message
         if sub_id:
             conn.execute(
-                f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
-                f"WHERE local_id in ({submitted_variants})"
+                text(
+                    f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
+                    f"WHERE local_id in ({submitted_variants})"
+                )
             )
         else:
             error = response.get('message')
             conn.execute(
-                f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
-                f"WHERE local_id in ({submitted_variants})"
+                text(
+                    f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
+                    f"WHERE local_id in ({submitted_variants})"
+                )
             )
 
 

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -85,8 +85,7 @@ def add_submission_id_to_db(response, engine, variants):
     Outputs:
         None, adds data to db
     '''
-    add_quotes = [f"'{x}'" for x in variants]
-    submitted_variants = ", ".join(add_quotes)
+
     sub_id = response.get('id')
     with engine.begin() as conn:
         # If submission ID exists, update the inca table with it
@@ -94,18 +93,20 @@ def add_submission_id_to_db(response, engine, variants):
         if sub_id:
             conn.execute(
                 text(
-                    f"UPDATE testdirectory.inca SET submission_id = '{sub_id}' "
-                    f"WHERE local_id in ({submitted_variants})"
-                )
-            )
+                    "UPDATE testdirectory.inca SET submission_id = :sub_id "
+                    "WHERE local_id = ANY(:variants)"
+                 ),
+                 {"sub_id": sub_id, "variants": variants}
+             )
         else:
             error = response.get('message')
             conn.execute(
                 text(
-                    f"UPDATE testdirectory.inca SET clinvar_status = 'ERROR: {error}' "
-                    f"WHERE local_id in ({submitted_variants})"
+                    "UPDATE testdirectory.inca SET clinvar_status = :error "
+                    "WHERE local_id = ANY(:variants)"
+                    ),
+                    {"error": f"ERROR: {error}", "variants": variants}
                 )
-            )
 
 
 def select_variants_from_db(organisation_id, engine, submitted, exclude=""):

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -215,3 +215,24 @@ def add_clinvar_submission_error_to_db(errors, engine):
         # Batch submission which updates each local_id with its error
         conn.execute(query, payload)
 
+
+def set_DUP_for_duplicate_null_accession(engine):
+    """
+    Set accession_id = 'DUP' for all duplicate variants (same hgvsc, preferred_condition_name, organisation_id)
+    where accession_id IS NULL and another duplicate exists with accession_id IS NOT NULL.
+    """
+    query = text("""
+        UPDATE testdirectory.inca i
+        SET accession_id = 'DUP'
+        WHERE i.accession_id IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM testdirectory.inca j
+            WHERE j.hgvsc = i.hgvsc
+              AND j.preferred_condition_name = i.preferred_condition_name
+              AND j.organisation_id = i.organisation_id
+              AND j.accession_id IS NOT NULL
+          )
+    """)
+    with engine.begin() as conn:
+        conn.execute(query)

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -236,10 +236,7 @@ def set_DUP_for_germline_duplicates(engine):
           AND EXISTS (
             SELECT 1
             FROM testdirectory.inca j
-            WHERE j.chromosome = i.chromosome
-              AND j.start = i.start
-              AND j.reference_allele = i.reference_allele
-              AND j.alternate_allele = i.alternate_allele
+            WHERE j.hgvsc = i.hgvsc
               AND j.preferred_condition_name = i.preferred_condition_name
               AND j.organisation_id = i.organisation_id
               AND j.accession_id IS NOT NULL

--- a/utils/database_actions.py
+++ b/utils/database_actions.py
@@ -220,22 +220,30 @@ def add_clinvar_submission_error_to_db(errors, engine):
         conn.execute(query, payload)
 
 
-def set_DUP_for_duplicate_null_accession(engine):
+def set_DUP_for_germline_duplicates(engine):
     """
-    Set accession_id = 'DUP' for all duplicate variants (same hgvsc, preferred_condition_name, organisation_id)
+    Set accession_id = 'DUP' for all duplicate germline variants
+    (same chrom, pos, ref, alt, preferred_condition_name, organisation_id)
     where accession_id IS NULL and another duplicate exists with accession_id IS NOT NULL.
     """
     query = text("""
         UPDATE testdirectory.inca i
         SET accession_id = 'DUP'
         WHERE i.accession_id IS NULL
+        AND i.interpreted = 'yes'
+        AND i.allele_origin = 'germline'
           AND EXISTS (
             SELECT 1
             FROM testdirectory.inca j
-            WHERE j.hgvsc = i.hgvsc
+            WHERE j.chromosome = i.chromosome
+              AND j.start = i.start
+              AND j.reference_allele = i.reference_allele
+              AND j.alternate_allele = i.alternate_allele
               AND j.preferred_condition_name = i.preferred_condition_name
               AND j.organisation_id = i.organisation_id
               AND j.accession_id IS NOT NULL
+              AND j.interpreted = 'yes'
+              AND j.allele_origin = 'germline'
           )
     """)
     with engine.begin() as conn:


### PR DESCRIPTION
This pull request introduces a mechanism to automatically mark duplicate variants in the database by setting their `accession_id` to `'DUP'` when certain conditions are met.

**Duplicate variant handling:**
* Added a new function `set_DUP_for_duplicate_null_accession` in `utils/database_actions.py` that sets `accession_id` to `'DUP'` for variants that are duplicates (same `hgvsc`, `preferred_condition_name`, `organisation_id`) and currently have a null `accession_id`, provided another duplicate exists with a non-null `accession_id`.
* Updated the main workflow in `pandora.py` to call `set_DUP_for_duplicate_null_accession` before variant selection, ensuring duplicates are flagged prior to submission. The workflow also respects the `dry_run` flag to avoid unintended database changes during testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/27)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate variant records are automatically identified and marked earlier in the processing workflow.

* **Improvements**
  * Dry‑run mode reports intended duplicate markings without applying changes.
  * Duplicate handling now occurs before variant selection/exclusion, changing processing order and applying updates during runs.
  * Database updates use parameterised queries and run within transactions for safer updates.

* **Tests**
  * Tests updated to validate parameterised update behaviour for success and error paths; minor cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->