### PR TITLE
Fix numpy error in add_submission_id_to_db

### DIFF
--- a/pandora.py
+++ b/pandora.py
@@ -421,7 +421,7 @@ def main():
                 print(f"Submission response: {response.status_code}, {response.text}")
                 if args.clinvar_testing is False:
                     db.add_submission_id_to_db(
-                        response.json(), engine, df["local_id"].values
+                        response.json(), engine, df["local_id"].values.tolist()
                     )
     else:
         print("hold_for_review specified. Variants will not be submitted.")

--- a/pandora.py
+++ b/pandora.py
@@ -421,7 +421,7 @@ def main():
                 print(f"Submission response: {response.status_code}, {response.text}")
                 if args.clinvar_testing is False:
                     db.add_submission_id_to_db(
-                        response.json(), engine, df["local_id"].values.tolist()
+                        response.json(), engine, df["local_id"].tolist()
                     )
     else:
         print("hold_for_review specified. Variants will not be submitted.")


### PR DESCRIPTION
This pull request makes a minor update to how local IDs are passed to the `add_submission_id_to_db` function in `pandora.py`. The change replaces the use of `.values` with `.tolist()` to ensure the local IDs are provided as a standard Python list, which is required for SQL command. Previous handling for this was suggested to be removed by coderabbit.

* Changed `df["local_id"].values` to `df["local_id"].tolist()` when passing local IDs to `add_submission_id_to_db` in `pandora.py` for improved compatibility and clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/28)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the submission identifier recording process to properly format and handle submission data when storing records to the database. This improves system compatibility, reliability, and data consistency throughout the submission workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->