### PR TITLE
DI-3137 v1.1.1 Handle TULIP batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This script searches a given folder for Excel variant workbooks that have not pr
     ```
 * `--config`: config file, should be the config.json from https://github.com/eastgenomics/clinvar_submissions_config.
 * `--organisation`: Organisation to submit for, either "CUH" or "NUH". This determines which ClinVar API key and submission URL to use.
+* `--output_dir`: (path to output directory) the script will output any inconsistent/parsed Clarity files to this directory.
+
 ### One option which specifies the run-mode i.e. from clarity extract, workbooks path or samples_file:
 These are mutually exclusive, one must be specified.
 * `--path_to_workbooks`: Local path to Excel workbooks that need submitting.
@@ -40,7 +42,6 @@ These are mutually exclusive, one must be specified.
   * Test Directory Test Code
   * Test Validation Status
   * Last Final Verify Date
-* `--output_dir`: (path to output directory) If specified, the script will output any inconsistent/parsed clarity files to this directory.
 
 **Optional:**
 * `--use_paths`: (boolean) Default is False, if specified, will use the paths from the clarity extract directly. If False, will output a CSV for review.

--- a/pandora.py
+++ b/pandora.py
@@ -37,7 +37,8 @@ def parse_args() -> argparse.Namespace:
     Parse command line arguments
     """
     parser = argparse.ArgumentParser(
-        description="", formatter_class=(argparse.ArgumentDefaultsHelpFormatter)
+        description="",
+        formatter_class=(argparse.ArgumentDefaultsHelpFormatter),
     )
     parser.add_argument(
         "--clinvar_api_key",
@@ -57,8 +58,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--hold_for_review",
         action="store_true",
-        help="Boolean determining whether to hold submission of variants, "
-        "allowing for manual review in the db before submission.",
+        help=(
+            "Boolean determining whether to hold submission of variants, "
+            "allowing for manual review in the db before submission."
+        ),
     )
     parser.add_argument(
         "--db_credentials",
@@ -75,7 +78,9 @@ def parse_args() -> argparse.Namespace:
         help="Path to file containing Excel paths to workbooks in clingen",
     )
     parser.add_argument(
-        "--config", required=True, help="JSON config file containing required inputs"
+        "--config",
+        required=True,
+        help="JSON config file containing required inputs",
     )
     parser.add_argument(
         "--organisation",
@@ -86,11 +91,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dry_run",
         action="store_true",
-        help="Run the script without making any changes "
-        "to the database or submitting to ClinVar",
+        help=(
+            "Run the script without making any changes "
+            "to the database or submitting to ClinVar"
+        ),
     )
     parser.add_argument(
-        "--no_retry", action="store_true", help="Do not retry failed submissions"
+        "--no_retry",
+        action="store_true",
+        help="Do not retry failed submissions",
     )
     parser.add_argument(
         "--use_paths",
@@ -148,8 +157,9 @@ def output_inconsistent_files(
     # Output any inconsistent files for review
     if not data_issues_df.empty:
         print(
-            f"{data_issues_df.shape[0]} samples with data issues found in "
-            f"clarity extract. See data_issues_clarity_extract_{timestamp}.csv for details."
+            f"{data_issues_df.shape[0]} samples with data issues found in"
+            " clarity extract. See"
+            f" data_issues_clarity_extract_{timestamp}.csv for details."
         )
         path_to_missing = os.path.join(
             output_dir, f"data_issues_clarity_extract_{timestamp}.csv"
@@ -158,8 +168,9 @@ def output_inconsistent_files(
 
     if not clarity_issues_df.empty:
         print(
-            f"{clarity_issues_df.shape[0]} samples with issues found in "
-            f"input clarity extract. See clarity_issues_clarity_extract_{timestamp}.csv for details."
+            f"{clarity_issues_df.shape[0]} samples with issues found in input"
+            " clarity extract. See"
+            f" clarity_issues_clarity_extract_{timestamp}.csv for details."
         )
         path_to_clarity_issues = os.path.join(
             output_dir, f"clarity_issues_clarity_extract_{timestamp}.csv"
@@ -211,8 +222,12 @@ def main():
     else:
         # Identify cases in database which have a submission ID but no accession ID
         print("Searching for variants with no accession ID...")
-        cuh_submission_df = db.select_variants_from_db("288359", engine, "NOT NULL")
-        nuh_submission_df = db.select_variants_from_db("509428", engine, "NOT NULL")
+        cuh_submission_df = db.select_variants_from_db(
+            "288359", engine, "NOT NULL"
+        )
+        nuh_submission_df = db.select_variants_from_db(
+            "509428", engine, "NOT NULL"
+        )
 
         print(
             f"Found {nuh_submission_df.shape[0]} with submission IDs but no "
@@ -248,9 +263,9 @@ def main():
         filenames = glob.glob(os.path.join(args.path_to_workbooks, "*.xlsx"))
         # remove any CNV workbooks
         workbooks_to_process = [
-            f for f in filenames if not re.search(
-                r"(CNV|mosaic)", f, re.IGNORECASE
-            )
+            f
+            for f in filenames
+            if not re.search(r"(CNV|mosaic)", f, re.IGNORECASE)
         ]
         if not filenames:
             print("No workbooks found in the specified path.")
@@ -265,7 +280,9 @@ def main():
         )
         # remove any CNV workbooks and mosaic workbooks
         workbooks_to_process = samples_df[
-            ~samples_df["file_name"].str.contains("CNV|mosaic", case=False, na=False)
+            ~samples_df["file_name"].str.contains(
+                "CNV|mosaic", case=False, na=False
+            )
         ]["path"].tolist()
         print(f"Found {len(workbooks_to_process)} workbooks")
         # Output any inconsistent files for review
@@ -303,13 +320,13 @@ def main():
             if args.use_paths:
                 print("Using paths from clarity extract directly.")
                 # Check files exist and exclude any that don't
-                clarity_df, missing_file_paths_df = utils.check_files_exist_and_exclude(
-                    clarity_df, "path"
+                clarity_df, missing_file_paths_df = (
+                    utils.check_files_exist_and_exclude(clarity_df, "path")
                 )
                 if not missing_file_paths_df.empty:
                     missing_data_df = pd.concat(
                         [missing_data_df, missing_file_paths_df],
-                        ignore_index=True
+                        ignore_index=True,
                     )
 
                 workbooks_to_process = clarity_df["path"].dropna().tolist()
@@ -317,32 +334,45 @@ def main():
 
                 # Output any inconsistent files for review
                 output_inconsistent_files(
-                    missing_data_df, clarity_issues_df, timestamp, args.output_dir
+                    missing_data_df,
+                    clarity_issues_df,
+                    timestamp,
+                    args.output_dir,
                 )
             else:
                 print(
-                    "--use_paths not specified so outputting clarity extract dataframes for review."
+                    "--use_paths not specified so outputting clarity extract"
+                    " dataframes for review."
                 )
                 print("These can be processed by using --samples_file option.")
                 # Output samples file for review named with timestamp
                 path_to_parsed_clarity = os.path.join(
-                    args.output_dir, f"clarity_extract_parsed_paths_{timestamp}.csv"
+                    args.output_dir,
+                    f"clarity_extract_parsed_paths_{timestamp}.csv",
                 )
                 clarity_df.to_csv(
                     path_to_parsed_clarity,
                     index=False,
                 )
                 print(
-                    f"Clarity extract parsed paths output to {path_to_parsed_clarity}"
+                    "Clarity extract parsed paths output to"
+                    f" {path_to_parsed_clarity}"
                 )
                 output_inconsistent_files(
-                    missing_data_df, clarity_issues_df, timestamp, args.output_dir
+                    missing_data_df,
+                    clarity_issues_df,
+                    timestamp,
+                    args.output_dir,
                 )
 
     # Get previously parsed workbooks
-    parsed_workbook_df = db.select_workbooks_from_db(engine, "parse_status = TRUE")
+    parsed_workbook_df = db.select_workbooks_from_db(
+        engine, "parse_status = TRUE"
+    )
     parsed_list = parsed_workbook_df["workbook_name"].values
-    failed_parsing_df = db.select_workbooks_from_db(engine, "parse_status = FALSE")
+    failed_parsing_df = db.select_workbooks_from_db(
+        engine, "parse_status = FALSE"
+    )
     failed_list = failed_parsing_df["workbook_name"].values
 
     # Process workbooks
@@ -357,8 +387,9 @@ def main():
             )
             workbook = load_workbook(filename)
             if file not in failed_list:
-                # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
-                db.add_wb_to_db(file, None, engine)
+                if not args.dry_run:
+                    # Was "NULL" but None in SQLAlchemy becomes NULL in SQL
+                    db.add_wb_to_db(file, None, engine)
             # Get a df of data from each sheet in workbook:
             df = utils.get_workbook_data(
                 workbook, config, filename, file, engine, args.organisation
@@ -368,7 +399,9 @@ def main():
                 continue
             # If we reach this point, we have valid data
             if args.dry_run:
-                print(f"Parsed data:\n{df.head()}\n{df.shape[0]} rows in total.")
+                print(
+                    f"Parsed data:\n{df.head()}\n{df.shape[0]} rows in total."
+                )
                 df = None
             else:
                 if not df.empty:
@@ -387,17 +420,21 @@ def main():
 
         if not args.dry_run:
             print(
-            "Checking for duplicate variants... and setting accession_id to 'DUP'"
+                "Checking for duplicate variants... and setting accession_id"
+                " to 'DUP'"
             )
             db.set_DUP_for_germline_duplicates(engine)
         else:
-            print("Dry run specified. No changes will be made to the database.")
+            print(
+                "Dry run specified. No changes will be made to the database."
+            )
 
         cuh_df = db.select_variants_from_db("288359", engine, "NULL", exclude)
         nuh_df = db.select_variants_from_db("509428", engine, "NULL", exclude)
         print(
-            f"Found {nuh_df.shape[0]} interpreted variants to submit for NUH.\n"
-            f"Found {cuh_df.shape[0]} interpreted variants to submit for CUH."
+            f"Found {nuh_df.shape[0]} interpreted variants to submit for"
+            f" NUH.\nFound {cuh_df.shape[0]} interpreted variants to submit"
+            " for CUH."
         )
         cuh_df.url, cuh_df.header = config.get("CUH_acgs_url"), cuh_header
         nuh_df.url, nuh_df.header = config.get("NUH_acgs_url"), nuh_header
@@ -408,6 +445,12 @@ def main():
                 variants = clinvar.collect_clinvar_data_to_submit(
                     df, config["ref_genomes"]
                 )
+                if args.dry_run:
+                    print(
+                        f"Dry run: would submit {len(variants)} variants to"
+                        " ClinVar"
+                    )
+                    continue
                 response = clinvar.clinvar_api_request(
                     api_url,
                     df.header,
@@ -416,7 +459,10 @@ def main():
                     args.print_submission_json,
                     args.no_retry,
                 )
-                print(f"Submission response: {response.status_code}, {response.text}")
+                print(
+                    f"Submission response: {response.status_code},"
+                    f" {response.text}"
+                )
                 if args.clinvar_testing is False:
                     db.add_submission_id_to_db(
                         response.json(), engine, df["local_id"].tolist()

--- a/pandora.py
+++ b/pandora.py
@@ -37,8 +37,7 @@ def parse_args() -> argparse.Namespace:
     Parse command line arguments
     """
     parser = argparse.ArgumentParser(
-        description="",
-        formatter_class=(argparse.ArgumentDefaultsHelpFormatter),
+        description="", formatter_class=(argparse.ArgumentDefaultsHelpFormatter)
     )
     parser.add_argument(
         "--clinvar_api_key",
@@ -58,10 +57,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--hold_for_review",
         action="store_true",
-        help=(
-            "Boolean determining whether to hold submission of variants, "
-            "allowing for manual review in the db before submission."
-        ),
+        help="Boolean determining whether to hold submission of variants, "
+        "allowing for manual review in the db before submission.",
     )
     parser.add_argument(
         "--db_credentials",
@@ -78,9 +75,7 @@ def parse_args() -> argparse.Namespace:
         help="Path to file containing Excel paths to workbooks in clingen",
     )
     parser.add_argument(
-        "--config",
-        required=True,
-        help="JSON config file containing required inputs",
+        "--config", required=True, help="JSON config file containing required inputs"
     )
     parser.add_argument(
         "--organisation",
@@ -91,15 +86,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dry_run",
         action="store_true",
-        help=(
-            "Run the script without making any changes "
-            "to the database or submitting to ClinVar"
-        ),
+        help="Run the script without making any changes "
+        "to the database or submitting to ClinVar",
     )
     parser.add_argument(
-        "--no_retry",
-        action="store_true",
-        help="Do not retry failed submissions",
+        "--no_retry", action="store_true", help="Do not retry failed submissions"
     )
     parser.add_argument(
         "--use_paths",
@@ -157,9 +148,8 @@ def output_inconsistent_files(
     # Output any inconsistent files for review
     if not data_issues_df.empty:
         print(
-            f"{data_issues_df.shape[0]} samples with data issues found in"
-            " clarity extract. See"
-            f" data_issues_clarity_extract_{timestamp}.csv for details."
+            f"{data_issues_df.shape[0]} samples with data issues found in "
+            f"clarity extract. See data_issues_clarity_extract_{timestamp}.csv for details."
         )
         path_to_missing = os.path.join(
             output_dir, f"data_issues_clarity_extract_{timestamp}.csv"
@@ -168,9 +158,8 @@ def output_inconsistent_files(
 
     if not clarity_issues_df.empty:
         print(
-            f"{clarity_issues_df.shape[0]} samples with issues found in input"
-            " clarity extract. See"
-            f" clarity_issues_clarity_extract_{timestamp}.csv for details."
+            f"{clarity_issues_df.shape[0]} samples with issues found in "
+            f"input clarity extract. See clarity_issues_clarity_extract_{timestamp}.csv for details."
         )
         path_to_clarity_issues = os.path.join(
             output_dir, f"clarity_issues_clarity_extract_{timestamp}.csv"
@@ -222,12 +211,8 @@ def main():
     else:
         # Identify cases in database which have a submission ID but no accession ID
         print("Searching for variants with no accession ID...")
-        cuh_submission_df = db.select_variants_from_db(
-            "288359", engine, "NOT NULL"
-        )
-        nuh_submission_df = db.select_variants_from_db(
-            "509428", engine, "NOT NULL"
-        )
+        cuh_submission_df = db.select_variants_from_db("288359", engine, "NOT NULL")
+        nuh_submission_df = db.select_variants_from_db("509428", engine, "NOT NULL")
 
         print(
             f"Found {nuh_submission_df.shape[0]} with submission IDs but no "
@@ -263,9 +248,9 @@ def main():
         filenames = glob.glob(os.path.join(args.path_to_workbooks, "*.xlsx"))
         # remove any CNV workbooks
         workbooks_to_process = [
-            f
-            for f in filenames
-            if not re.search(r"(CNV|mosaic)", f, re.IGNORECASE)
+            f for f in filenames if not re.search(
+                r"(CNV|mosaic)", f, re.IGNORECASE
+            )
         ]
         if not filenames:
             print("No workbooks found in the specified path.")
@@ -280,9 +265,7 @@ def main():
         )
         # remove any CNV workbooks and mosaic workbooks
         workbooks_to_process = samples_df[
-            ~samples_df["file_name"].str.contains(
-                "CNV|mosaic", case=False, na=False
-            )
+            ~samples_df["file_name"].str.contains("CNV|mosaic", case=False, na=False)
         ]["path"].tolist()
         print(f"Found {len(workbooks_to_process)} workbooks")
         # Output any inconsistent files for review
@@ -320,13 +303,13 @@ def main():
             if args.use_paths:
                 print("Using paths from clarity extract directly.")
                 # Check files exist and exclude any that don't
-                clarity_df, missing_file_paths_df = (
-                    utils.check_files_exist_and_exclude(clarity_df, "path")
+                clarity_df, missing_file_paths_df = utils.check_files_exist_and_exclude(
+                    clarity_df, "path"
                 )
                 if not missing_file_paths_df.empty:
                     missing_data_df = pd.concat(
                         [missing_data_df, missing_file_paths_df],
-                        ignore_index=True,
+                        ignore_index=True
                     )
 
                 workbooks_to_process = clarity_df["path"].dropna().tolist()
@@ -334,45 +317,32 @@ def main():
 
                 # Output any inconsistent files for review
                 output_inconsistent_files(
-                    missing_data_df,
-                    clarity_issues_df,
-                    timestamp,
-                    args.output_dir,
+                    missing_data_df, clarity_issues_df, timestamp, args.output_dir
                 )
             else:
                 print(
-                    "--use_paths not specified so outputting clarity extract"
-                    " dataframes for review."
+                    "--use_paths not specified so outputting clarity extract dataframes for review."
                 )
                 print("These can be processed by using --samples_file option.")
                 # Output samples file for review named with timestamp
                 path_to_parsed_clarity = os.path.join(
-                    args.output_dir,
-                    f"clarity_extract_parsed_paths_{timestamp}.csv",
+                    args.output_dir, f"clarity_extract_parsed_paths_{timestamp}.csv"
                 )
                 clarity_df.to_csv(
                     path_to_parsed_clarity,
                     index=False,
                 )
                 print(
-                    "Clarity extract parsed paths output to"
-                    f" {path_to_parsed_clarity}"
+                    f"Clarity extract parsed paths output to {path_to_parsed_clarity}"
                 )
                 output_inconsistent_files(
-                    missing_data_df,
-                    clarity_issues_df,
-                    timestamp,
-                    args.output_dir,
+                    missing_data_df, clarity_issues_df, timestamp, args.output_dir
                 )
 
     # Get previously parsed workbooks
-    parsed_workbook_df = db.select_workbooks_from_db(
-        engine, "parse_status = TRUE"
-    )
+    parsed_workbook_df = db.select_workbooks_from_db(engine, "parse_status = TRUE")
     parsed_list = parsed_workbook_df["workbook_name"].values
-    failed_parsing_df = db.select_workbooks_from_db(
-        engine, "parse_status = FALSE"
-    )
+    failed_parsing_df = db.select_workbooks_from_db(engine, "parse_status = FALSE")
     failed_list = failed_parsing_df["workbook_name"].values
 
     # Process workbooks
@@ -399,9 +369,7 @@ def main():
                 continue
             # If we reach this point, we have valid data
             if args.dry_run:
-                print(
-                    f"Parsed data:\n{df.head()}\n{df.shape[0]} rows in total."
-                )
+                print(f"Parsed data:\n{df.head()}\n{df.shape[0]} rows in total.")
                 df = None
             else:
                 if not df.empty:
@@ -420,21 +388,17 @@ def main():
 
         if not args.dry_run:
             print(
-                "Checking for duplicate variants... and setting accession_id"
-                " to 'DUP'"
+            "Checking for duplicate variants... and setting accession_id to 'DUP'"
             )
             db.set_DUP_for_germline_duplicates(engine)
         else:
-            print(
-                "Dry run specified. No changes will be made to the database."
-            )
+            print("Dry run specified. No changes will be made to the database.")
 
         cuh_df = db.select_variants_from_db("288359", engine, "NULL", exclude)
         nuh_df = db.select_variants_from_db("509428", engine, "NULL", exclude)
         print(
-            f"Found {nuh_df.shape[0]} interpreted variants to submit for"
-            f" NUH.\nFound {cuh_df.shape[0]} interpreted variants to submit"
-            " for CUH."
+            f"Found {nuh_df.shape[0]} interpreted variants to submit for NUH.\n"
+            f"Found {cuh_df.shape[0]} interpreted variants to submit for CUH."
         )
         cuh_df.url, cuh_df.header = config.get("CUH_acgs_url"), cuh_header
         nuh_df.url, nuh_df.header = config.get("NUH_acgs_url"), nuh_header
@@ -447,8 +411,8 @@ def main():
                 )
                 if args.dry_run:
                     print(
-                        f"Dry run: would submit {len(variants)} variants to"
-                        " ClinVar"
+                        f"Dry run: would submit {len(variants)} variants to "
+                        "ClinVar"
                     )
                     continue
                 response = clinvar.clinvar_api_request(
@@ -459,10 +423,7 @@ def main():
                     args.print_submission_json,
                     args.no_retry,
                 )
-                print(
-                    f"Submission response: {response.status_code},"
-                    f" {response.text}"
-                )
+                print(f"Submission response: {response.status_code}, {response.text}")
                 if args.clinvar_testing is False:
                     db.add_submission_id_to_db(
                         response.json(), engine, df["local_id"].tolist()

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -35,10 +35,7 @@ def test_open_files_with_example(example_csv):
     expected_df = pd.DataFrame(
         {
             "Beaker Procedure Name": ["WES NGS", "CEN NGS"],
-            "Received Specimen Date Time": [
-                "2024-01-25 03:55",
-                "2024-02-21 11:08",
-            ],
+            "Received Specimen Date Time": ["2024-01-25 03:55", "2024-02-21 11:08"],
             "Specimen Identifier": ["SP-24015R0015", "SP-24010R0031"],
             "Test Directory Test Code": ["R149.1", "R208.1"],
             "Test Validation Status": ["Verified", "Verified"],
@@ -76,8 +73,7 @@ def test_create_path_cen():
         "002_251010_A01303_0320_BACWV9DRX7_37_CEN",
     )
     expected = Path(
-        "/mnt/clingen/CEN/Run"
-        " folders/251010_A01303_0320_BACWV9DRX7_CEN/file.xlsx"
+        "/mnt/clingen/CEN/Run folders/251010_A01303_0320_BACWV9DRX7_CEN/file.xlsx"
     )
     assert isinstance(path, Path)
     assert path == expected
@@ -91,9 +87,7 @@ def test_create_path_wes():
         "WES",
         "002_251010_A01303_0120_AHCWV8DRX7_38_TWE",
     )
-    expected = Path(
-        "/mnt/clingen/WES/251010_A01303_0120_AHCWV8DRX7_TWE/file.xlsx"
-    )
+    expected = Path("/mnt/clingen/WES/251010_A01303_0120_AHCWV8DRX7_TWE/file.xlsx")
     assert isinstance(path, Path)
     assert path == expected
 
@@ -101,8 +95,7 @@ def test_create_path_wes():
 def test_create_path_nan():
     """Test path creation with NaN run folder returns None."""
     assert (
-        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", pd.NA)
-        is pd.NA
+        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", pd.NA) is pd.NA
     )
 
 
@@ -122,10 +115,7 @@ def test_create_path_unknown_assay():
 def test_create_path_short_run_folder():
     """Test path creation with short run folder returns None."""
     assert (
-        ceh.create_path(
-            "file.xlsx", Path("/mnt/clingen/"), "CEN", "002_251010"
-        )
-        is pd.NA
+        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", "002_251010") is pd.NA
     )
 
 
@@ -171,16 +161,12 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
     mock_find_data_objects.return_value = [
         {
             "describe": {
-                "name": (
-                    "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
-                )
+                "name": "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
             }
         },
         {
             "describe": {
-                "name": (
-                    "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
-                )
+                "name": "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
             }
         },
     ]
@@ -191,16 +177,12 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
         {
             "sample_id": "25110R0008",
             "project_id": "proj-1",
-            "file_name": (
-                "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
-            ),
+            "file_name": "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx",
         },
         {
             "sample_id": "25110R0009",
             "project_id": "proj-1",
-            "file_name": (
-                "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
-            ),
+            "file_name": "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx",
         },
     ]
     assert records == expected_list
@@ -208,7 +190,6 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
 
 class TestFetchAllReports:
     """Test fetching all reports in chunks"""
-
     def test_fetch_all_reports_success(self):
         df = pd.DataFrame({"sample_id": ["S1", "S2", "S3"]})
         fake_projects = {"p1": "Project1"}
@@ -217,36 +198,19 @@ class TestFetchAllReports:
             {"sample_id": "S2", "project_id": "p1", "file_name": "file2.txt"},
         ]
 
-        with patch(
-            "utils.clarity_extract_handler.get_matching_projects",
-            return_value=fake_projects,
-        ):
-            with patch(
-                "utils.clarity_extract_handler.query_reports_for_project",
-                return_value=fake_records,
-            ):
+        with patch("utils.clarity_extract_handler.get_matching_projects", return_value=fake_projects):
+            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=fake_records):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         assert out.shape[0] == 3
-        assert (
-            out.loc[out.sample_id == "S1", "file_name"].iloc[0] == "file1.txt"
-        )
-        assert (
-            out.loc[out.sample_id == "S1", "project_name"].iloc[0]
-            == "Project1"
-        )
+        assert out.loc[out.sample_id == "S1", "file_name"].iloc[0] == "file1.txt"
+        assert out.loc[out.sample_id == "S1", "project_name"].iloc[0] == "Project1"
 
     def test_fetch_all_reports_no_results(self):
         df = pd.DataFrame({"sample_id": ["A", "B"]})
 
-        with patch(
-            "utils.clarity_extract_handler.get_matching_projects",
-            return_value={"p": "Proj"},
-        ):
-            with patch(
-                "utils.clarity_extract_handler.query_reports_for_project",
-                return_value=[],
-            ):
+        with patch("utils.clarity_extract_handler.get_matching_projects", return_value={"p": "Proj"}):
+            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=[]):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         assert out["file_name"].isna().all()
@@ -263,14 +227,8 @@ class TestFetchAllReports:
             {"sample_id": "S1", "project_id": "p2", "file_name": "f2"},
         ]
 
-        with patch(
-            "utils.clarity_extract_handler.get_matching_projects",
-            return_value=fake_projects,
-        ):
-            with patch(
-                "utils.clarity_extract_handler.query_reports_for_project",
-                return_value=fake_records,
-            ):
+        with patch("utils.clarity_extract_handler.get_matching_projects", return_value=fake_projects):
+            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=fake_records):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         # S1 should be removed entirely
@@ -279,7 +237,6 @@ class TestFetchAllReports:
 
 class TestRCodeMatching:
     """Test R code matching in filenames."""
-
     @pytest.fixture
     def example_df(self):
         csv_path = (
@@ -350,9 +307,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
-            example_df
-        )
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -393,9 +348,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
-            example_df
-        )
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -436,9 +389,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
-            example_df
-        )
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -461,8 +412,8 @@ class TestPreProcessClarityExtract:
                 "R_codes": [[], []],
                 "issue": [
                     "Missing or multiple R codes in Clarity extract",
-                    "Missing or multiple R codes in Clarity extract",
-                ],
+                    "Missing or multiple R codes in Clarity extract"
+                ]
             }
         )
         pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
@@ -476,9 +427,7 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
-            example_df
-        )
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
 
         expected_df = pd.DataFrame(
             {
@@ -501,8 +450,8 @@ class TestPreProcessClarityExtract:
                 "R_codes": [["R208", "R209"], []],
                 "issue": [
                     "Missing or multiple R codes in Clarity extract",
-                    "Missing or multiple R codes in Clarity extract",
-                ],
+                    "Missing or multiple R codes in Clarity extract"
+                ]
             }
         )
 
@@ -515,9 +464,7 @@ class TestPreprocessReportDf:
     def test_preprocess_report_df(self):
         example_df = pd.DataFrame(
             {
-                "file_name": [
-                    "129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
-                ],
+                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
                 "sample_id": ["24123R0012"],
                 "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
             }
@@ -528,18 +475,11 @@ class TestPreprocessReportDf:
 
         expected_df = pd.DataFrame(
             {
-                "file_name": [
-                    "129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
-                ],
+                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
                 "sample_id": ["24123R0012"],
                 "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
                 "Assay": ["CEN"],
-                "path": [
-                    Path(
-                        "/test_workbooks/CEN/Run"
-                        " folders/240516_A01303_0387_BH7F2WDRX5_CEN/129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
-                    )
-                ],
+                "path": [Path("/test_workbooks/CEN/Run folders/240516_A01303_0387_BH7F2WDRX5_CEN/129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx")],
                 "instrument_id": ["129740955"],
                 "full_sample_id": ["129740955-24123R0012"],
                 "report_r_code": ["R228.1"],
@@ -581,7 +521,6 @@ class TestPreprocessReportDf:
 
 class TestFilteringReports:
     """Test filtering of reports DataFrame."""
-
     def test_filtering_one_report_with_matching_r_code(self):
         example_df = pd.DataFrame(
             {
@@ -598,11 +537,15 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": ["002_251117_test_38_CEN"],
+                "project_name": [
+                    "002_251117_test_38_CEN"
+                ],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": ["129740958-24123R0015"],
+                "full_sample_id": [
+                    "129740958-24123R0015"
+                ]
             }
         )
 
@@ -623,35 +566,35 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": ["002_251117_test_38_CEN"],
+                "project_name": [
+                    "002_251117_test_38_CEN"
+                ],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": ["129740958-24123R0015"],
+                "full_sample_id": [
+                    "129740958-24123R0015"
+                ]
             }
         )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame(
-            {
-                "file_name": pd.Series(dtype="object"),
-                "sample_id": pd.Series(dtype="object"),
-                "report_r_code": pd.Series(dtype="object"),
-                "R_codes": pd.Series(dtype="object"),
-                "project_id": pd.Series(dtype="object"),
-                "project_name": pd.Series(dtype="object"),
-                "Assay": pd.Series(dtype="object"),
-                "path": pd.Series(dtype="object"),
-                "instrument_id": pd.Series(dtype="object"),
-                "full_sample_id": pd.Series(dtype="object"),
-                "issue": pd.Series(dtype="object"),
-            }
-        )
+        expected_missing_data_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object'),
+            'project_id': pd.Series(dtype='object'),
+            'project_name': pd.Series(dtype='object'),
+            'Assay': pd.Series(dtype='object'),
+            'path': pd.Series(dtype='object'),
+            'instrument_id': pd.Series(dtype='object'),
+            'full_sample_id': pd.Series(dtype='object'),
+            "issue": pd.Series(dtype='object')
+        })
 
-        pd.testing.assert_frame_equal(
-            missing_data_df, expected_missing_data_df
-        )
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
 
     def test_filtering_multiple_reports_one_matches_clarity_r_code(self):
         example_df = pd.DataFrame(
@@ -668,62 +611,55 @@ class TestFilteringReports:
                     "R228.1",
                     "R149.1",
                 ],
-                "R_codes": [["R228"], ["R228"]],
+                "R_codes": [
+                    ["R228"],
+                    ["R228"]
+                ],
                 "project_id": ["project-x", "project-y"],
                 "project_name": [
-                    "002_251117_test_38_CEN",
-                    "002_251112_test_38_TWE",
+                    "002_251117_test_38_CEN", "002_251112_test_38_TWE"
                 ],
                 "Assay": ["CEN", "TWE"],
                 "path": ["test", "test"],
                 "instrument_id": ["129740958", "129740958"],
                 "full_sample_id": [
-                    "129740958-24123R0015",
-                    "129740958-24123R0015",
-                ],
+                    "129740958-24123R0015", "129740958-24123R0015"
+                ]
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
 
-        expected_filtered_df = pd.DataFrame(
-            {
-                "file_name": [
-                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx"
-                ],
-                "sample_id": ["24123R0015"],
-                "report_r_code": ["R228.1"],
-                "R_codes": [["R228"]],
-                "project_id": ["project-x"],
-                "project_name": ["002_251117_test_38_CEN"],
-                "Assay": ["CEN"],
-                "path": ["test"],
-                "instrument_id": ["129740958"],
-                "full_sample_id": ["129740958-24123R0015"],
-            }
-        )
+        expected_filtered_df = pd.DataFrame({
+            'file_name': ["129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx"],
+            'sample_id': ["24123R0015"],
+            'report_r_code': ["R228.1"],
+            'R_codes': [["R228"]],
+            "project_id": ["project-x"],
+            "project_name": ["002_251117_test_38_CEN"],
+            "Assay": ["CEN"],
+            "path": ["test"],
+            "instrument_id": ["129740958"],
+            "full_sample_id": ["129740958-24123R0015"]
+        })
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame(
-            {
-                "file_name": pd.Series(dtype="object"),
-                "sample_id": pd.Series(dtype="object"),
-                "report_r_code": pd.Series(dtype="object"),
-                "R_codes": pd.Series(dtype="object"),
-                "project_id": pd.Series(dtype="object"),
-                "project_name": pd.Series(dtype="object"),
-                "Assay": pd.Series(dtype="object"),
-                "path": pd.Series(dtype="object"),
-                "instrument_id": pd.Series(dtype="object"),
-                "full_sample_id": pd.Series(dtype="object"),
-                "issue": pd.Series(dtype="object"),
-            }
-        )
+        expected_missing_data_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object'),
+            'project_id': pd.Series(dtype='object'),
+            'project_name': pd.Series(dtype='object'),
+            'Assay': pd.Series(dtype='object'),
+            'path': pd.Series(dtype='object'),
+            'instrument_id': pd.Series(dtype='object'),
+            'full_sample_id': pd.Series(dtype='object'),
+            "issue": pd.Series(dtype='object')
+        })
 
-        pd.testing.assert_frame_equal(
-            missing_data_df, expected_missing_data_df
-        )
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
 
     def test_filtering_multiple_reports_none_match_clarity_r_code(self):
         example_df = pd.DataFrame(
@@ -741,54 +677,52 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": ["002_251117_test_38_CEN"],
+                "project_name": [
+                    "002_251117_test_38_CEN"
+                ],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": ["129740958-24123R0015"],
+                "full_sample_id": [
+                    "129740958-24123R0015"
+                ]
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
 
-        expected_filtered_df = pd.DataFrame(
-            {
-                "file_name": pd.Series(dtype="object"),
-                "sample_id": pd.Series(dtype="object"),
-                "report_r_code": pd.Series(dtype="object"),
-                "R_codes": pd.Series(dtype="object"),
-                "project_id": pd.Series(dtype="object"),
-                "project_name": pd.Series(dtype="object"),
-                "Assay": pd.Series(dtype="object"),
-                "path": pd.Series(dtype="object"),
-                "instrument_id": pd.Series(dtype="object"),
-                "full_sample_id": pd.Series(dtype="object"),
-            }
-        )
+        expected_filtered_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object'),
+            'project_id': pd.Series(dtype='object'),
+            'project_name': pd.Series(dtype='object'),
+            'Assay': pd.Series(dtype='object'),
+            'path': pd.Series(dtype='object'),
+            'instrument_id': pd.Series(dtype='object'),
+            'full_sample_id': pd.Series(dtype='object'),
+        })
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame(
-            {
-                "file_name": [
-                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
-                ],
-                "sample_id": ["24123R0015"],
-                "report_r_code": ["R149.1"],
-                "R_codes": [["R228"]],
-                "project_id": ["project-x"],
-                "project_name": ["002_251117_test_38_CEN"],
-                "Assay": ["CEN"],
-                "path": ["test"],
-                "instrument_id": ["129740958"],
-                "full_sample_id": ["129740958-24123R0015"],
-                "issue": "R code mismatch",
-            }
-        )
+        expected_missing_data_df = pd.DataFrame({
+            'file_name': [
+                "129740958-24123R0015-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
+            ],
+            'sample_id': ["24123R0015"],
+            'report_r_code': ["R149.1"],
+            'R_codes': [["R228"]],
+            "project_id": ["project-x"],
+            "project_name": ["002_251117_test_38_CEN"],
+            "Assay": ["CEN"],
+            "path": ["test"],
+            "instrument_id": ["129740958"],
+            "full_sample_id": ["129740958-24123R0015"],
+            "issue": "R code mismatch"
+        })
 
-        pd.testing.assert_frame_equal(
-            missing_data_df, expected_missing_data_df
-        )
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
 
     def test_filtering_no_filename(self):
         example_df = pd.DataFrame(
@@ -799,7 +733,9 @@ class TestFilteringReports:
                 "sample_id": [
                     "24123R0015",
                 ],
-                "report_r_code": [pd.NA],
+                "report_r_code": [
+                    pd.NA
+                ],
                 "R_codes": [
                     ["R228"],
                 ],
@@ -808,25 +744,23 @@ class TestFilteringReports:
                 "Assay": [pd.NA],
                 "path": [pd.NA],
                 "instrument_id": [pd.NA],
-                "full_sample_id": [pd.NA],
+                "full_sample_id": [pd.NA]
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
-        expected_filtered_df = pd.DataFrame(
-            {
-                "file_name": pd.Series(dtype="object"),
-                "sample_id": pd.Series(dtype="object"),
-                "report_r_code": pd.Series(dtype="object"),
-                "R_codes": pd.Series(dtype="object"),
-                "project_id": pd.Series(dtype="object"),
-                "project_name": pd.Series(dtype="object"),
-                "Assay": pd.Series(dtype="object"),
-                "path": pd.Series(dtype="object"),
-                "instrument_id": pd.Series(dtype="object"),
-                "full_sample_id": pd.Series(dtype="object"),
-            }
-        )
+        expected_filtered_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object'),
+            'project_id': pd.Series(dtype='object'),
+            'project_name': pd.Series(dtype='object'),
+            'Assay': pd.Series(dtype='object'),
+            'path': pd.Series(dtype='object'),
+            'instrument_id': pd.Series(dtype='object'),
+            'full_sample_id': pd.Series(dtype='object'),
+        })
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
@@ -843,56 +777,49 @@ class TestFilteringReports:
                 "instrument_id": [pd.NA],
                 "full_sample_id": [pd.NA],
                 "issue": [
-                    "No DNAnexus data or cannot parse fields from DNAnexus"
-                    " data"
-                ],
+                    "No DNAnexus data or cannot parse fields from DNAnexus data"
+                ]
             }
         )
 
-        pd.testing.assert_frame_equal(
-            missing_data_df, expected_missing_data_df
-        )
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
 
     def test_filtering_multiple_reports_same_r_code(self):
         example_df = pd.DataFrame(
             {
                 "file_name": [
                     "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
-                    "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
+                    "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
                 ],
                 "sample_id": ["24123R0016", "24123R0016"],
-                "report_r_code": ["R149.1", "R149.1"],
+                "report_r_code": [
+                    "R149.1", "R149.1"
+                ],
                 "R_codes": [
-                    ["R149"],
-                    ["R149"],
+                    ["R149"], ["R149"],
                 ],
                 "project_id": ["project-x", "project-x"],
                 "project_name": ["002_251117_XXX_CEN", "002_251117_XXX_CEN"],
                 "Assay": ["CEN", "CEN"],
                 "path": ["test", "test"],
                 "instrument_id": ["129740959", "129740959"],
-                "full_sample_id": [
-                    "129740959-24123R0016",
-                    "129740959-24123R0016",
-                ],
+                "full_sample_id": ["129740959-24123R0016", "129740959-24123R0016"]
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
-        expected_filtered_df = pd.DataFrame(
-            {
-                "file_name": pd.Series(dtype="object"),
-                "sample_id": pd.Series(dtype="object"),
-                "report_r_code": pd.Series(dtype="object"),
-                "R_codes": pd.Series(dtype="object"),
-                "project_id": pd.Series(dtype="object"),
-                "project_name": pd.Series(dtype="object"),
-                "Assay": pd.Series(dtype="object"),
-                "path": pd.Series(dtype="object"),
-                "instrument_id": pd.Series(dtype="object"),
-                "full_sample_id": pd.Series(dtype="object"),
-            }
-        )
+        expected_filtered_df = pd.DataFrame({
+            'file_name': pd.Series(dtype='object'),
+            'sample_id': pd.Series(dtype='object'),
+            'report_r_code': pd.Series(dtype='object'),
+            'R_codes': pd.Series(dtype='object'),
+            'project_id': pd.Series(dtype='object'),
+            'project_name': pd.Series(dtype='object'),
+            'Assay': pd.Series(dtype='object'),
+            'path': pd.Series(dtype='object'),
+            'instrument_id': pd.Series(dtype='object'),
+            'full_sample_id': pd.Series(dtype='object'),
+        })
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
@@ -902,7 +829,9 @@ class TestFilteringReports:
                     "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
                 ],
                 "sample_id": ["24123R0016"],
-                "report_r_code": ["R149.1"],
+                "report_r_code": [
+                    "R149.1"
+                ],
                 "R_codes": [
                     ["R149"],
                 ],
@@ -912,10 +841,8 @@ class TestFilteringReports:
                 "path": ["test"],
                 "instrument_id": ["129740959"],
                 "full_sample_id": ["129740959-24123R0016"],
-                "issue": ["Multiple reports"],
+                "issue": ["Multiple reports"]
             }
         )
 
-        pd.testing.assert_frame_equal(
-            missing_data_df, expected_missing_data_df
-        )
+        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -235,6 +235,45 @@ class TestFetchAllReports:
         assert out.empty
 
 
+class TestExtractAssay:
+    """Test extracting assay from DNAnexus project name"""
+    def test_valid_cen_38(self):
+        assert ceh.extract_assay(
+            "002_260410_A01303_0752_BHLC3LDRX7_38_CEN"
+        ) == "CEN"
+
+    def test_valid_cen_37(self):
+        assert ceh.extract_assay(
+            "002_260410_A01303_0752_BHLC3LDRX7_CEN"
+        ) == "CEN"
+
+    def test_valid_wes_38(self):
+        assert ceh.extract_assay(
+            "002_250924_A01303_0632_AHCFJFDRX7_38_TWE"
+        ) == "TWE"
+
+    def test_valid_wes_37(self):
+        assert ceh.extract_assay(
+            "002_250924_A01303_0632_AHCFJFDRX7_TWE"
+        ) == "TWE"
+
+    def test_no_assay(self):
+        assert ceh.extract_assay(
+            "002_250924_A01303_0632_AHCFJFDRX7"
+        ) is pd.NA
+
+    def test_unknown_assay(self):
+        assert ceh.extract_assay(
+            "002_250924_A01303_0632_AHCFJFDRX7_UNKNOWN"
+        ) is pd.NA
+
+    def test_extract_assay_returns_na_when_input_is_none(self):
+        assert pd.isna(ceh.extract_assay(None))
+
+    def test_extract_assay_returns_na_when_input_is_na(self):
+        assert pd.isna(ceh.extract_assay(pd.NA))
+
+
 class TestRCodeMatching:
     """Test R code matching in filenames."""
     @pytest.fixture

--- a/tests/test_clarity_extract_handler.py
+++ b/tests/test_clarity_extract_handler.py
@@ -35,7 +35,10 @@ def test_open_files_with_example(example_csv):
     expected_df = pd.DataFrame(
         {
             "Beaker Procedure Name": ["WES NGS", "CEN NGS"],
-            "Received Specimen Date Time": ["2024-01-25 03:55", "2024-02-21 11:08"],
+            "Received Specimen Date Time": [
+                "2024-01-25 03:55",
+                "2024-02-21 11:08",
+            ],
             "Specimen Identifier": ["SP-24015R0015", "SP-24010R0031"],
             "Test Directory Test Code": ["R149.1", "R208.1"],
             "Test Validation Status": ["Verified", "Verified"],
@@ -73,7 +76,8 @@ def test_create_path_cen():
         "002_251010_A01303_0320_BACWV9DRX7_37_CEN",
     )
     expected = Path(
-        "/mnt/clingen/CEN/Run folders/251010_A01303_0320_BACWV9DRX7_CEN/file.xlsx"
+        "/mnt/clingen/CEN/Run"
+        " folders/251010_A01303_0320_BACWV9DRX7_CEN/file.xlsx"
     )
     assert isinstance(path, Path)
     assert path == expected
@@ -87,7 +91,9 @@ def test_create_path_wes():
         "WES",
         "002_251010_A01303_0120_AHCWV8DRX7_38_TWE",
     )
-    expected = Path("/mnt/clingen/WES/251010_A01303_0120_AHCWV8DRX7_TWE/file.xlsx")
+    expected = Path(
+        "/mnt/clingen/WES/251010_A01303_0120_AHCWV8DRX7_TWE/file.xlsx"
+    )
     assert isinstance(path, Path)
     assert path == expected
 
@@ -95,7 +101,8 @@ def test_create_path_wes():
 def test_create_path_nan():
     """Test path creation with NaN run folder returns None."""
     assert (
-        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", pd.NA) is pd.NA
+        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", pd.NA)
+        is pd.NA
     )
 
 
@@ -115,7 +122,10 @@ def test_create_path_unknown_assay():
 def test_create_path_short_run_folder():
     """Test path creation with short run folder returns None."""
     assert (
-        ceh.create_path("file.xlsx", Path("/mnt/clingen/"), "CEN", "002_251010") is pd.NA
+        ceh.create_path(
+            "file.xlsx", Path("/mnt/clingen/"), "CEN", "002_251010"
+        )
+        is pd.NA
     )
 
 
@@ -161,12 +171,16 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
     mock_find_data_objects.return_value = [
         {
             "describe": {
-                "name": "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
+                "name": (
+                    "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
+                )
             }
         },
         {
             "describe": {
-                "name": "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
+                "name": (
+                    "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
+                )
             }
         },
     ]
@@ -177,12 +191,16 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
         {
             "sample_id": "25110R0008",
             "project_id": "proj-1",
-            "file_name": "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx",
+            "file_name": (
+                "119696617-25110R0008-25NGCEN82-9527-M-97444487_R208.1_SNV_1.xlsx"
+            ),
         },
         {
             "sample_id": "25110R0009",
             "project_id": "proj-1",
-            "file_name": "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx",
+            "file_name": (
+                "123696617-25110R0009-25NGCEN82-9527-F-97444487_R208.1_SNV_1.xlsx"
+            ),
         },
     ]
     assert records == expected_list
@@ -190,6 +208,7 @@ def test_query_reports_for_project_exact_id_match(mock_find_data_objects):
 
 class TestFetchAllReports:
     """Test fetching all reports in chunks"""
+
     def test_fetch_all_reports_success(self):
         df = pd.DataFrame({"sample_id": ["S1", "S2", "S3"]})
         fake_projects = {"p1": "Project1"}
@@ -198,19 +217,36 @@ class TestFetchAllReports:
             {"sample_id": "S2", "project_id": "p1", "file_name": "file2.txt"},
         ]
 
-        with patch("utils.clarity_extract_handler.get_matching_projects", return_value=fake_projects):
-            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=fake_records):
+        with patch(
+            "utils.clarity_extract_handler.get_matching_projects",
+            return_value=fake_projects,
+        ):
+            with patch(
+                "utils.clarity_extract_handler.query_reports_for_project",
+                return_value=fake_records,
+            ):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         assert out.shape[0] == 3
-        assert out.loc[out.sample_id == "S1", "file_name"].iloc[0] == "file1.txt"
-        assert out.loc[out.sample_id == "S1", "project_name"].iloc[0] == "Project1"
+        assert (
+            out.loc[out.sample_id == "S1", "file_name"].iloc[0] == "file1.txt"
+        )
+        assert (
+            out.loc[out.sample_id == "S1", "project_name"].iloc[0]
+            == "Project1"
+        )
 
     def test_fetch_all_reports_no_results(self):
         df = pd.DataFrame({"sample_id": ["A", "B"]})
 
-        with patch("utils.clarity_extract_handler.get_matching_projects", return_value={"p": "Proj"}):
-            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=[]):
+        with patch(
+            "utils.clarity_extract_handler.get_matching_projects",
+            return_value={"p": "Proj"},
+        ):
+            with patch(
+                "utils.clarity_extract_handler.query_reports_for_project",
+                return_value=[],
+            ):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         assert out["file_name"].isna().all()
@@ -227,31 +263,23 @@ class TestFetchAllReports:
             {"sample_id": "S1", "project_id": "p2", "file_name": "f2"},
         ]
 
-        with patch("utils.clarity_extract_handler.get_matching_projects", return_value=fake_projects):
-            with patch("utils.clarity_extract_handler.query_reports_for_project", return_value=fake_records):
+        with patch(
+            "utils.clarity_extract_handler.get_matching_projects",
+            return_value=fake_projects,
+        ):
+            with patch(
+                "utils.clarity_extract_handler.query_reports_for_project",
+                return_value=fake_records,
+            ):
                 out = ceh.fetch_all_reports(df, assays=["CEN"])
 
         # S1 should be removed entirely
         assert out.empty
 
-class TestExtractAssayFromFilename:
-    """Test extracting assay from filename."""
-
-    def test_valid_cen(self):
-        assert ceh.extract_assay_from_filename("file_CEN_123.xlsx") == "CEN"
-
-    def test_valid_wes(self):
-        assert ceh.extract_assay_from_filename("file_WES_123.xlsx") == "WES"
-
-    def test_no_assay(self):
-        assert ceh.extract_assay_from_filename("file_123.xlsx") is pd.NA
-
-    def test_unknown_assay(self):
-        assert ceh.extract_assay_from_filename("file_UNKNOWN_123.xlsx") is pd.NA
-
 
 class TestRCodeMatching:
     """Test R code matching in filenames."""
+
     @pytest.fixture
     def example_df(self):
         csv_path = (
@@ -322,7 +350,9 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
+            example_df
+        )
 
         expected_df = pd.DataFrame(
             {
@@ -363,7 +393,9 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
+            example_df
+        )
 
         expected_df = pd.DataFrame(
             {
@@ -404,7 +436,9 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
+            example_df
+        )
 
         expected_df = pd.DataFrame(
             {
@@ -427,8 +461,8 @@ class TestPreProcessClarityExtract:
                 "R_codes": [[], []],
                 "issue": [
                     "Missing or multiple R codes in Clarity extract",
-                    "Missing or multiple R codes in Clarity extract"
-                ]
+                    "Missing or multiple R codes in Clarity extract",
+                ],
             }
         )
         pd.testing.assert_frame_equal(clarity_issues_df, expected_issues_df)
@@ -442,7 +476,9 @@ class TestPreProcessClarityExtract:
             }
         )
 
-        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(example_df)
+        processed_df, clarity_issues_df = ceh.preprocess_clarity_extract(
+            example_df
+        )
 
         expected_df = pd.DataFrame(
             {
@@ -465,8 +501,8 @@ class TestPreProcessClarityExtract:
                 "R_codes": [["R208", "R209"], []],
                 "issue": [
                     "Missing or multiple R codes in Clarity extract",
-                    "Missing or multiple R codes in Clarity extract"
-                ]
+                    "Missing or multiple R codes in Clarity extract",
+                ],
             }
         )
 
@@ -479,7 +515,9 @@ class TestPreprocessReportDf:
     def test_preprocess_report_df(self):
         example_df = pd.DataFrame(
             {
-                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
+                "file_name": [
+                    "129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
+                ],
                 "sample_id": ["24123R0012"],
                 "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
             }
@@ -490,11 +528,18 @@ class TestPreprocessReportDf:
 
         expected_df = pd.DataFrame(
             {
-                "file_name": ["129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"],
+                "file_name": [
+                    "129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
+                ],
                 "sample_id": ["24123R0012"],
                 "project_name": ["002_240516_A01303_0387_BH7F2WDRX5_38_CEN"],
                 "Assay": ["CEN"],
-                "path": [Path("/test_workbooks/CEN/Run folders/240516_A01303_0387_BH7F2WDRX5_CEN/129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx")],
+                "path": [
+                    Path(
+                        "/test_workbooks/CEN/Run"
+                        " folders/240516_A01303_0387_BH7F2WDRX5_CEN/129740955-24123R0012-24NGCEN42-9527-F-99347387_R228.1_SNV_1.xlsx"
+                    )
+                ],
                 "instrument_id": ["129740955"],
                 "full_sample_id": ["129740955-24123R0012"],
                 "report_r_code": ["R228.1"],
@@ -536,6 +581,7 @@ class TestPreprocessReportDf:
 
 class TestFilteringReports:
     """Test filtering of reports DataFrame."""
+
     def test_filtering_one_report_with_matching_r_code(self):
         example_df = pd.DataFrame(
             {
@@ -552,15 +598,11 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": [
-                    "002_251117_test_38_CEN"
-                ],
+                "project_name": ["002_251117_test_38_CEN"],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": [
-                    "129740958-24123R0015"
-                ]
+                "full_sample_id": ["129740958-24123R0015"],
             }
         )
 
@@ -581,35 +623,35 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": [
-                    "002_251117_test_38_CEN"
-                ],
+                "project_name": ["002_251117_test_38_CEN"],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": [
-                    "129740958-24123R0015"
-                ]
+                "full_sample_id": ["129740958-24123R0015"],
             }
         )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame({
-            'file_name': pd.Series(dtype='object'),
-            'sample_id': pd.Series(dtype='object'),
-            'report_r_code': pd.Series(dtype='object'),
-            'R_codes': pd.Series(dtype='object'),
-            'project_id': pd.Series(dtype='object'),
-            'project_name': pd.Series(dtype='object'),
-            'Assay': pd.Series(dtype='object'),
-            'path': pd.Series(dtype='object'),
-            'instrument_id': pd.Series(dtype='object'),
-            'full_sample_id': pd.Series(dtype='object'),
-            "issue": pd.Series(dtype='object')
-        })
+        expected_missing_data_df = pd.DataFrame(
+            {
+                "file_name": pd.Series(dtype="object"),
+                "sample_id": pd.Series(dtype="object"),
+                "report_r_code": pd.Series(dtype="object"),
+                "R_codes": pd.Series(dtype="object"),
+                "project_id": pd.Series(dtype="object"),
+                "project_name": pd.Series(dtype="object"),
+                "Assay": pd.Series(dtype="object"),
+                "path": pd.Series(dtype="object"),
+                "instrument_id": pd.Series(dtype="object"),
+                "full_sample_id": pd.Series(dtype="object"),
+                "issue": pd.Series(dtype="object"),
+            }
+        )
 
-        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+        pd.testing.assert_frame_equal(
+            missing_data_df, expected_missing_data_df
+        )
 
     def test_filtering_multiple_reports_one_matches_clarity_r_code(self):
         example_df = pd.DataFrame(
@@ -626,55 +668,62 @@ class TestFilteringReports:
                     "R228.1",
                     "R149.1",
                 ],
-                "R_codes": [
-                    ["R228"],
-                    ["R228"]
-                ],
+                "R_codes": [["R228"], ["R228"]],
                 "project_id": ["project-x", "project-y"],
                 "project_name": [
-                    "002_251117_test_38_CEN", "002_251112_test_38_TWE"
+                    "002_251117_test_38_CEN",
+                    "002_251112_test_38_TWE",
                 ],
                 "Assay": ["CEN", "TWE"],
                 "path": ["test", "test"],
                 "instrument_id": ["129740958", "129740958"],
                 "full_sample_id": [
-                    "129740958-24123R0015", "129740958-24123R0015"
-                ]
+                    "129740958-24123R0015",
+                    "129740958-24123R0015",
+                ],
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
 
-        expected_filtered_df = pd.DataFrame({
-            'file_name': ["129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx"],
-            'sample_id': ["24123R0015"],
-            'report_r_code': ["R228.1"],
-            'R_codes': [["R228"]],
-            "project_id": ["project-x"],
-            "project_name": ["002_251117_test_38_CEN"],
-            "Assay": ["CEN"],
-            "path": ["test"],
-            "instrument_id": ["129740958"],
-            "full_sample_id": ["129740958-24123R0015"]
-        })
+        expected_filtered_df = pd.DataFrame(
+            {
+                "file_name": [
+                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R228.1_SNV_1.xlsx"
+                ],
+                "sample_id": ["24123R0015"],
+                "report_r_code": ["R228.1"],
+                "R_codes": [["R228"]],
+                "project_id": ["project-x"],
+                "project_name": ["002_251117_test_38_CEN"],
+                "Assay": ["CEN"],
+                "path": ["test"],
+                "instrument_id": ["129740958"],
+                "full_sample_id": ["129740958-24123R0015"],
+            }
+        )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame({
-            'file_name': pd.Series(dtype='object'),
-            'sample_id': pd.Series(dtype='object'),
-            'report_r_code': pd.Series(dtype='object'),
-            'R_codes': pd.Series(dtype='object'),
-            'project_id': pd.Series(dtype='object'),
-            'project_name': pd.Series(dtype='object'),
-            'Assay': pd.Series(dtype='object'),
-            'path': pd.Series(dtype='object'),
-            'instrument_id': pd.Series(dtype='object'),
-            'full_sample_id': pd.Series(dtype='object'),
-            "issue": pd.Series(dtype='object')
-        })
+        expected_missing_data_df = pd.DataFrame(
+            {
+                "file_name": pd.Series(dtype="object"),
+                "sample_id": pd.Series(dtype="object"),
+                "report_r_code": pd.Series(dtype="object"),
+                "R_codes": pd.Series(dtype="object"),
+                "project_id": pd.Series(dtype="object"),
+                "project_name": pd.Series(dtype="object"),
+                "Assay": pd.Series(dtype="object"),
+                "path": pd.Series(dtype="object"),
+                "instrument_id": pd.Series(dtype="object"),
+                "full_sample_id": pd.Series(dtype="object"),
+                "issue": pd.Series(dtype="object"),
+            }
+        )
 
-        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+        pd.testing.assert_frame_equal(
+            missing_data_df, expected_missing_data_df
+        )
 
     def test_filtering_multiple_reports_none_match_clarity_r_code(self):
         example_df = pd.DataFrame(
@@ -692,52 +741,54 @@ class TestFilteringReports:
                     ["R228"],
                 ],
                 "project_id": ["project-x"],
-                "project_name": [
-                    "002_251117_test_38_CEN"
-                ],
+                "project_name": ["002_251117_test_38_CEN"],
                 "Assay": ["CEN"],
                 "path": ["test"],
                 "instrument_id": ["129740958"],
-                "full_sample_id": [
-                    "129740958-24123R0015"
-                ]
+                "full_sample_id": ["129740958-24123R0015"],
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
 
-        expected_filtered_df = pd.DataFrame({
-            'file_name': pd.Series(dtype='object'),
-            'sample_id': pd.Series(dtype='object'),
-            'report_r_code': pd.Series(dtype='object'),
-            'R_codes': pd.Series(dtype='object'),
-            'project_id': pd.Series(dtype='object'),
-            'project_name': pd.Series(dtype='object'),
-            'Assay': pd.Series(dtype='object'),
-            'path': pd.Series(dtype='object'),
-            'instrument_id': pd.Series(dtype='object'),
-            'full_sample_id': pd.Series(dtype='object'),
-        })
+        expected_filtered_df = pd.DataFrame(
+            {
+                "file_name": pd.Series(dtype="object"),
+                "sample_id": pd.Series(dtype="object"),
+                "report_r_code": pd.Series(dtype="object"),
+                "R_codes": pd.Series(dtype="object"),
+                "project_id": pd.Series(dtype="object"),
+                "project_name": pd.Series(dtype="object"),
+                "Assay": pd.Series(dtype="object"),
+                "path": pd.Series(dtype="object"),
+                "instrument_id": pd.Series(dtype="object"),
+                "full_sample_id": pd.Series(dtype="object"),
+            }
+        )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
-        expected_missing_data_df = pd.DataFrame({
-            'file_name': [
-                "129740958-24123R0015-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
-            ],
-            'sample_id': ["24123R0015"],
-            'report_r_code': ["R149.1"],
-            'R_codes': [["R228"]],
-            "project_id": ["project-x"],
-            "project_name": ["002_251117_test_38_CEN"],
-            "Assay": ["CEN"],
-            "path": ["test"],
-            "instrument_id": ["129740958"],
-            "full_sample_id": ["129740958-24123R0015"],
-            "issue": "R code mismatch"
-        })
+        expected_missing_data_df = pd.DataFrame(
+            {
+                "file_name": [
+                    "129740958-24123R0015-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
+                ],
+                "sample_id": ["24123R0015"],
+                "report_r_code": ["R149.1"],
+                "R_codes": [["R228"]],
+                "project_id": ["project-x"],
+                "project_name": ["002_251117_test_38_CEN"],
+                "Assay": ["CEN"],
+                "path": ["test"],
+                "instrument_id": ["129740958"],
+                "full_sample_id": ["129740958-24123R0015"],
+                "issue": "R code mismatch",
+            }
+        )
 
-        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+        pd.testing.assert_frame_equal(
+            missing_data_df, expected_missing_data_df
+        )
 
     def test_filtering_no_filename(self):
         example_df = pd.DataFrame(
@@ -748,9 +799,7 @@ class TestFilteringReports:
                 "sample_id": [
                     "24123R0015",
                 ],
-                "report_r_code": [
-                    pd.NA
-                ],
+                "report_r_code": [pd.NA],
                 "R_codes": [
                     ["R228"],
                 ],
@@ -759,23 +808,25 @@ class TestFilteringReports:
                 "Assay": [pd.NA],
                 "path": [pd.NA],
                 "instrument_id": [pd.NA],
-                "full_sample_id": [pd.NA]
+                "full_sample_id": [pd.NA],
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
-        expected_filtered_df = pd.DataFrame({
-            'file_name': pd.Series(dtype='object'),
-            'sample_id': pd.Series(dtype='object'),
-            'report_r_code': pd.Series(dtype='object'),
-            'R_codes': pd.Series(dtype='object'),
-            'project_id': pd.Series(dtype='object'),
-            'project_name': pd.Series(dtype='object'),
-            'Assay': pd.Series(dtype='object'),
-            'path': pd.Series(dtype='object'),
-            'instrument_id': pd.Series(dtype='object'),
-            'full_sample_id': pd.Series(dtype='object'),
-        })
+        expected_filtered_df = pd.DataFrame(
+            {
+                "file_name": pd.Series(dtype="object"),
+                "sample_id": pd.Series(dtype="object"),
+                "report_r_code": pd.Series(dtype="object"),
+                "R_codes": pd.Series(dtype="object"),
+                "project_id": pd.Series(dtype="object"),
+                "project_name": pd.Series(dtype="object"),
+                "Assay": pd.Series(dtype="object"),
+                "path": pd.Series(dtype="object"),
+                "instrument_id": pd.Series(dtype="object"),
+                "full_sample_id": pd.Series(dtype="object"),
+            }
+        )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
@@ -792,49 +843,56 @@ class TestFilteringReports:
                 "instrument_id": [pd.NA],
                 "full_sample_id": [pd.NA],
                 "issue": [
-                    "No DNAnexus data or cannot parse fields from DNAnexus data"
-                ]
+                    "No DNAnexus data or cannot parse fields from DNAnexus"
+                    " data"
+                ],
             }
         )
 
-        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+        pd.testing.assert_frame_equal(
+            missing_data_df, expected_missing_data_df
+        )
 
     def test_filtering_multiple_reports_same_r_code(self):
         example_df = pd.DataFrame(
             {
                 "file_name": [
                     "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
-                    "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx"
+                    "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
                 ],
                 "sample_id": ["24123R0016", "24123R0016"],
-                "report_r_code": [
-                    "R149.1", "R149.1"
-                ],
+                "report_r_code": ["R149.1", "R149.1"],
                 "R_codes": [
-                    ["R149"], ["R149"],
+                    ["R149"],
+                    ["R149"],
                 ],
                 "project_id": ["project-x", "project-x"],
                 "project_name": ["002_251117_XXX_CEN", "002_251117_XXX_CEN"],
                 "Assay": ["CEN", "CEN"],
                 "path": ["test", "test"],
                 "instrument_id": ["129740959", "129740959"],
-                "full_sample_id": ["129740959-24123R0016", "129740959-24123R0016"]
+                "full_sample_id": [
+                    "129740959-24123R0016",
+                    "129740959-24123R0016",
+                ],
             }
         )
 
         filtered_df, missing_data_df = ceh.filtering_reports(example_df)
-        expected_filtered_df = pd.DataFrame({
-            'file_name': pd.Series(dtype='object'),
-            'sample_id': pd.Series(dtype='object'),
-            'report_r_code': pd.Series(dtype='object'),
-            'R_codes': pd.Series(dtype='object'),
-            'project_id': pd.Series(dtype='object'),
-            'project_name': pd.Series(dtype='object'),
-            'Assay': pd.Series(dtype='object'),
-            'path': pd.Series(dtype='object'),
-            'instrument_id': pd.Series(dtype='object'),
-            'full_sample_id': pd.Series(dtype='object'),
-        })
+        expected_filtered_df = pd.DataFrame(
+            {
+                "file_name": pd.Series(dtype="object"),
+                "sample_id": pd.Series(dtype="object"),
+                "report_r_code": pd.Series(dtype="object"),
+                "R_codes": pd.Series(dtype="object"),
+                "project_id": pd.Series(dtype="object"),
+                "project_name": pd.Series(dtype="object"),
+                "Assay": pd.Series(dtype="object"),
+                "path": pd.Series(dtype="object"),
+                "instrument_id": pd.Series(dtype="object"),
+                "full_sample_id": pd.Series(dtype="object"),
+            }
+        )
 
         pd.testing.assert_frame_equal(filtered_df, expected_filtered_df)
 
@@ -844,9 +902,7 @@ class TestFilteringReports:
                     "129740959-24123R0016-24NGCEN42-9527-F-99347390_R149.1_SNV_1.xlsx",
                 ],
                 "sample_id": ["24123R0016"],
-                "report_r_code": [
-                    "R149.1"
-                ],
+                "report_r_code": ["R149.1"],
                 "R_codes": [
                     ["R149"],
                 ],
@@ -856,8 +912,10 @@ class TestFilteringReports:
                 "path": ["test"],
                 "instrument_id": ["129740959"],
                 "full_sample_id": ["129740959-24123R0016"],
-                "issue": ["Multiple reports"]
+                "issue": ["Multiple reports"],
             }
         )
 
-        pd.testing.assert_frame_equal(missing_data_df, expected_missing_data_df)
+        pd.testing.assert_frame_equal(
+            missing_data_df, expected_missing_data_df
+        )

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -68,8 +68,8 @@ def preprocess_clarity_extract(clarity_df):
     )
 
     clarity_issues_df = clarity_df[
-        (clarity_df["R_codes"].str.len() == 0) |
-        (clarity_df["R_codes"].str.len() > 1)
+        (clarity_df["R_codes"].str.len() == 0)
+        | (clarity_df["R_codes"].str.len() > 1)
     ].copy()
 
     if not clarity_issues_df.empty:
@@ -99,8 +99,7 @@ def get_matching_projects(assays):
 
     matching_projects = list(
         dxpy.find_projects(
-            name={"regexp": re_pattern},
-            describe={"fields": {"name": True}}
+            name={"regexp": re_pattern}, describe={"fields": {"name": True}}
         )
     )
     matching_projects_dict = {
@@ -200,7 +199,8 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     # Chunk sample IDs to manage search load
     chunks = [
-        sample_ids[i : i + chunk_size] for i in range(0, len(sample_ids), chunk_size)
+        sample_ids[i : i + chunk_size]
+        for i in range(0, len(sample_ids), chunk_size)
     ]
 
     tasks = [
@@ -228,7 +228,9 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     if all_records:
         for record in all_records:
-            record["project_name"] = project_dict.get(record["project_id"], "Unknown")
+            record["project_name"] = project_dict.get(
+                record["project_id"], "Unknown"
+            )
 
         records_df = pd.DataFrame(all_records)
         print(f"Total reports fetched: {records_df.shape[0]}")
@@ -307,7 +309,8 @@ def create_path(filename, base_path, assay, run):
         path = base_path / "WES" / run_folder / filename
     else:
         print(
-            f"Warning: Unknown assay '{assay}' for filename {filename}. Returning None."
+            f"Warning: Unknown assay '{assay}' for filename {filename}."
+            " Returning None."
         )
         return pd.NA
     return path
@@ -348,24 +351,6 @@ def is_report_code_in_list(row) -> bool:
     return target in normalized_codes
 
 
-def extract_assay_from_filename(filename):
-    """
-    Extract the assay type from the given filename.
-
-    Inputs:
-        filename (str): The name of the file from which to extract the assay
-        type.
-
-    Outputs:
-        str or pd.NA: The extracted assay type (CEN or WES) or pd.NA if not
-        found.
-    """
-    if filename is None or pd.isna(filename):
-        return pd.NA
-    match = re.search(r"(CEN|WES)", filename)
-    return match.group(1) if match else pd.NA
-
-
 def filtering_reports(report_df):
     """
     Filter out reports based on if:
@@ -387,8 +372,15 @@ def filtering_reports(report_df):
         columns=report_df.columns.tolist() + ["issue"]
     )
     required = [
-        'file_name', 'project_id', 'project_name', 'Assay', 'path',
-        'instrument_id', 'full_sample_id', 'report_r_code', 'sample_id'
+        "file_name",
+        "project_id",
+        "project_name",
+        "Assay",
+        "path",
+        "instrument_id",
+        "full_sample_id",
+        "report_r_code",
+        "sample_id",
     ]
     missing_mask = report_df[required].isna().any(axis=1)
     if missing_mask.any():
@@ -405,22 +397,23 @@ def filtering_reports(report_df):
 
     # If no valid rows remain, return immediately
     if working_df.empty:
-        return (
-            pd.DataFrame(columns=report_df.columns),
-            data_issues_df
-        )
+        return (pd.DataFrame(columns=report_df.columns), data_issues_df)
 
     ## Remove and report rows where the R code in DX doesn't match
-    working_df["rcode_match"] = working_df.apply(is_report_code_in_list, axis=1)
+    working_df["rcode_match"] = working_df.apply(
+        is_report_code_in_list, axis=1
+    )
     valid_samples = set(working_df.loc[working_df["rcode_match"], "sample_id"])
     rcode_mismatch = working_df[
-        (~working_df["rcode_match"]) &
-        (~working_df["sample_id"].isin(valid_samples))
+        (~working_df["rcode_match"])
+        & (~working_df["sample_id"].isin(valid_samples))
     ].copy()
 
     if not rcode_mismatch.empty:
         rcode_mismatch["issue"] = "R code mismatch"
-        rcode_mismatch = rcode_mismatch.drop(columns=["rcode_match"], errors="ignore")
+        rcode_mismatch = rcode_mismatch.drop(
+            columns=["rcode_match"], errors="ignore"
+        )
         data_issues_df = pd.concat(
             [data_issues_df, rcode_mismatch], ignore_index=True
         )
@@ -429,10 +422,7 @@ def filtering_reports(report_df):
     working_df = working_df[working_df["rcode_match"]].copy()
     working_df = working_df.drop(columns=["rcode_match"], errors="ignore")
     if working_df.empty:
-        return (
-            pd.DataFrame(columns=report_df.columns),
-            data_issues_df
-        )
+        return (pd.DataFrame(columns=report_df.columns), data_issues_df)
 
     # Remove rows where there's multiple SNV reports per sample for same R
     # code
@@ -444,8 +434,9 @@ def filtering_reports(report_df):
     if not duplicate_groups.empty:
         # Keep ONE row per duplicated sample for the issues dataframe
         one_issue_row_per_sample = (
-            duplicate_groups
-            .sort_values(["Assay", "report_r_code", "sample_id"])
+            duplicate_groups.sort_values(
+                ["Assay", "report_r_code", "sample_id"]
+            )
             .groupby(["Assay", "report_r_code", "sample_id"], as_index=False)
             .first()
         )
@@ -455,15 +446,12 @@ def filtering_reports(report_df):
         )
 
         data_issues_df = pd.concat(
-            [data_issues_df, one_issue_row_per_sample],
-            ignore_index=True
+            [data_issues_df, one_issue_row_per_sample], ignore_index=True
         )
 
     # Keep only unique rows in filtered_df
     filtered_df = working_df[working_df["dup_count"] == 1].copy()
-    filtered_df = filtered_df.drop(
-        columns=["dup_count"], errors="ignore"
-    )
+    filtered_df = filtered_df.drop(columns=["dup_count"], errors="ignore")
 
     # Ensure filtered_df has all columns even if empty
     if filtered_df.empty:
@@ -486,11 +474,17 @@ def preprocess_report_df(report_df, base_path):
         columns.
     """
     # Extract assay from filename
-    report_df["Assay"] = report_df["file_name"].apply(extract_assay_from_filename)
+    report_df["Assay"] = (
+        report_df["project_name"]
+        .str.extract(r"_([^_]+)$", expand=False)
+        .where(report_df["project_name"].notna(), pd.NA)
+    )
 
     # Add the path to the processed reports
     report_df["path"] = report_df.apply(
-        lambda x: create_path(x["file_name"], base_path, x["Assay"], x["project_name"]),
+        lambda x: create_path(
+            x["file_name"], base_path, x["Assay"], x["project_name"]
+        ),
         axis=1,
     )
 
@@ -510,9 +504,7 @@ def preprocess_report_df(report_df, base_path):
     return report_df
 
 
-def handle_clarity_extract(
-    clarity_extract_path, assays, base_path
-):
+def handle_clarity_extract(clarity_extract_path, assays, base_path):
     """
     Main function to handle clarity extract and return paths to workbooks
     Inputs:
@@ -538,8 +530,15 @@ def handle_clarity_extract(
         empty_df = pd.DataFrame(
             columns=list(clarity_df.columns)
             + [
-                'file_name', 'project_id', 'project_name', 'R_codes', 'Assay',
-                'path', 'instrument_id', 'full_sample_id', 'report_r_code'
+                "file_name",
+                "project_id",
+                "project_name",
+                "R_codes",
+                "Assay",
+                "path",
+                "instrument_id",
+                "full_sample_id",
+                "report_r_code",
             ]
         )
         return clarity_df_preprocessed, empty_df.copy(), clarity_issues_df
@@ -553,8 +552,6 @@ def handle_clarity_extract(
     # Filter out all rows with no DX data, no reports matching the R code
     # or multiple reports for same R code
     filtered_df, data_issues_df = filtering_reports(report_df)
-    print(
-        f"Total reports remaining after filtering: {filtered_df.shape[0]}"
-    )
+    print(f"Total reports remaining after filtering: {filtered_df.shape[0]}")
 
     return filtered_df, data_issues_df, clarity_issues_df

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -454,6 +454,26 @@ def filtering_reports(report_df):
     return filtered_df, data_issues_df
 
 
+def extract_assay(project_name: str) -> str:
+    """
+    Extract assay from DNAnexus project_name (expecting "CEN" or "TWE")
+
+    Parameters
+    ----------
+    project_name : str
+        DNAnexus project name
+
+    Returns
+    -------
+    str or pd.NA
+        The extracted assay type (i.e. CEN or TWE) or pd.NA if not found
+    """
+    if project_name is None or pd.isna(project_name):
+        return pd.NA
+    match = re.search(r"_(CEN|TWE)$", project_name)
+    return match.group(1) if match else pd.NA
+
+
 def preprocess_report_df(report_df, base_path):
     """
     Preprocess the report DataFrame by adding necessary columns and cleaning
@@ -467,12 +487,8 @@ def preprocess_report_df(report_df, base_path):
         report_df (pd.DataFrame): Preprocessed DataFrame with additional
         columns.
     """
-    # Extract assay from filename
-    report_df["Assay"] = (
-        report_df["project_name"]
-        .str.extract(r"_([^_]+)$", expand=False)
-        .where(report_df["project_name"].notna(), pd.NA)
-    )
+    # Extract assay from DNAnexus project name
+    report_df["Assay"] = report_df["project_name"].apply(extract_assay)
 
     # Add the path to the processed reports
     report_df["path"] = report_df.apply(

--- a/utils/clarity_extract_handler.py
+++ b/utils/clarity_extract_handler.py
@@ -68,8 +68,8 @@ def preprocess_clarity_extract(clarity_df):
     )
 
     clarity_issues_df = clarity_df[
-        (clarity_df["R_codes"].str.len() == 0)
-        | (clarity_df["R_codes"].str.len() > 1)
+        (clarity_df["R_codes"].str.len() == 0) |
+        (clarity_df["R_codes"].str.len() > 1)
     ].copy()
 
     if not clarity_issues_df.empty:
@@ -99,7 +99,8 @@ def get_matching_projects(assays):
 
     matching_projects = list(
         dxpy.find_projects(
-            name={"regexp": re_pattern}, describe={"fields": {"name": True}}
+            name={"regexp": re_pattern},
+            describe={"fields": {"name": True}}
         )
     )
     matching_projects_dict = {
@@ -199,8 +200,7 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     # Chunk sample IDs to manage search load
     chunks = [
-        sample_ids[i : i + chunk_size]
-        for i in range(0, len(sample_ids), chunk_size)
+        sample_ids[i : i + chunk_size] for i in range(0, len(sample_ids), chunk_size)
     ]
 
     tasks = [
@@ -228,9 +228,7 @@ def fetch_all_reports(df, assays, chunk_size=100, max_workers=16):
 
     if all_records:
         for record in all_records:
-            record["project_name"] = project_dict.get(
-                record["project_id"], "Unknown"
-            )
+            record["project_name"] = project_dict.get(record["project_id"], "Unknown")
 
         records_df = pd.DataFrame(all_records)
         print(f"Total reports fetched: {records_df.shape[0]}")
@@ -309,8 +307,7 @@ def create_path(filename, base_path, assay, run):
         path = base_path / "WES" / run_folder / filename
     else:
         print(
-            f"Warning: Unknown assay '{assay}' for filename {filename}."
-            " Returning None."
+            f"Warning: Unknown assay '{assay}' for filename {filename}. Returning None."
         )
         return pd.NA
     return path
@@ -372,15 +369,8 @@ def filtering_reports(report_df):
         columns=report_df.columns.tolist() + ["issue"]
     )
     required = [
-        "file_name",
-        "project_id",
-        "project_name",
-        "Assay",
-        "path",
-        "instrument_id",
-        "full_sample_id",
-        "report_r_code",
-        "sample_id",
+        'file_name', 'project_id', 'project_name', 'Assay', 'path',
+        'instrument_id', 'full_sample_id', 'report_r_code', 'sample_id'
     ]
     missing_mask = report_df[required].isna().any(axis=1)
     if missing_mask.any():
@@ -397,23 +387,22 @@ def filtering_reports(report_df):
 
     # If no valid rows remain, return immediately
     if working_df.empty:
-        return (pd.DataFrame(columns=report_df.columns), data_issues_df)
+        return (
+            pd.DataFrame(columns=report_df.columns),
+            data_issues_df
+        )
 
     ## Remove and report rows where the R code in DX doesn't match
-    working_df["rcode_match"] = working_df.apply(
-        is_report_code_in_list, axis=1
-    )
+    working_df["rcode_match"] = working_df.apply(is_report_code_in_list, axis=1)
     valid_samples = set(working_df.loc[working_df["rcode_match"], "sample_id"])
     rcode_mismatch = working_df[
-        (~working_df["rcode_match"])
-        & (~working_df["sample_id"].isin(valid_samples))
+        (~working_df["rcode_match"]) &
+        (~working_df["sample_id"].isin(valid_samples))
     ].copy()
 
     if not rcode_mismatch.empty:
         rcode_mismatch["issue"] = "R code mismatch"
-        rcode_mismatch = rcode_mismatch.drop(
-            columns=["rcode_match"], errors="ignore"
-        )
+        rcode_mismatch = rcode_mismatch.drop(columns=["rcode_match"], errors="ignore")
         data_issues_df = pd.concat(
             [data_issues_df, rcode_mismatch], ignore_index=True
         )
@@ -422,7 +411,10 @@ def filtering_reports(report_df):
     working_df = working_df[working_df["rcode_match"]].copy()
     working_df = working_df.drop(columns=["rcode_match"], errors="ignore")
     if working_df.empty:
-        return (pd.DataFrame(columns=report_df.columns), data_issues_df)
+        return (
+            pd.DataFrame(columns=report_df.columns),
+            data_issues_df
+        )
 
     # Remove rows where there's multiple SNV reports per sample for same R
     # code
@@ -434,9 +426,8 @@ def filtering_reports(report_df):
     if not duplicate_groups.empty:
         # Keep ONE row per duplicated sample for the issues dataframe
         one_issue_row_per_sample = (
-            duplicate_groups.sort_values(
-                ["Assay", "report_r_code", "sample_id"]
-            )
+            duplicate_groups
+            .sort_values(["Assay", "report_r_code", "sample_id"])
             .groupby(["Assay", "report_r_code", "sample_id"], as_index=False)
             .first()
         )
@@ -446,12 +437,15 @@ def filtering_reports(report_df):
         )
 
         data_issues_df = pd.concat(
-            [data_issues_df, one_issue_row_per_sample], ignore_index=True
+            [data_issues_df, one_issue_row_per_sample],
+            ignore_index=True
         )
 
     # Keep only unique rows in filtered_df
     filtered_df = working_df[working_df["dup_count"] == 1].copy()
-    filtered_df = filtered_df.drop(columns=["dup_count"], errors="ignore")
+    filtered_df = filtered_df.drop(
+        columns=["dup_count"], errors="ignore"
+    )
 
     # Ensure filtered_df has all columns even if empty
     if filtered_df.empty:
@@ -482,9 +476,7 @@ def preprocess_report_df(report_df, base_path):
 
     # Add the path to the processed reports
     report_df["path"] = report_df.apply(
-        lambda x: create_path(
-            x["file_name"], base_path, x["Assay"], x["project_name"]
-        ),
+        lambda x: create_path(x["file_name"], base_path, x["Assay"], x["project_name"]),
         axis=1,
     )
 
@@ -504,7 +496,9 @@ def preprocess_report_df(report_df, base_path):
     return report_df
 
 
-def handle_clarity_extract(clarity_extract_path, assays, base_path):
+def handle_clarity_extract(
+    clarity_extract_path, assays, base_path
+):
     """
     Main function to handle clarity extract and return paths to workbooks
     Inputs:
@@ -530,15 +524,8 @@ def handle_clarity_extract(clarity_extract_path, assays, base_path):
         empty_df = pd.DataFrame(
             columns=list(clarity_df.columns)
             + [
-                "file_name",
-                "project_id",
-                "project_name",
-                "R_codes",
-                "Assay",
-                "path",
-                "instrument_id",
-                "full_sample_id",
-                "report_r_code",
+                'file_name', 'project_id', 'project_name', 'R_codes', 'Assay',
+                'path', 'instrument_id', 'full_sample_id', 'report_r_code'
             ]
         )
         return clarity_df_preprocessed, empty_df.copy(), clarity_issues_df
@@ -552,6 +539,8 @@ def handle_clarity_extract(clarity_extract_path, assays, base_path):
     # Filter out all rows with no DX data, no reports matching the R code
     # or multiple reports for same R code
     filtered_df, data_issues_df = filtering_reports(report_df)
-    print(f"Total reports remaining after filtering: {filtered_df.shape[0]}")
+    print(
+        f"Total reports remaining after filtering: {filtered_df.shape[0]}"
+    )
 
     return filtered_df, data_issues_df, clarity_issues_df


### PR DESCRIPTION
- When taking a Clarity extract and inferring clingen paths, extract the assay from the DNAnexus project name rather than the batch in the filename, as this breaks with TULIP batches (fix #36 )
- Remove function + unit tests for previous function to extract assay from NGS batch
- Properly guard database updates + ClinVar submission when using --dry_run

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/clinvar_submissions/38)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced --dry_run mode: preview ClinVar submissions and skip actual API requests and related database updates.

* **Bug Fixes**
  * Assay is now derived from project metadata rather than filename patterns for more reliable assignment.

* **Documentation**
  * README updated to document --output_dir and where parsed/inconsistent Clarity files are written.

* **Tests**
  * Removed obsolete filename-assay extraction test class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->